### PR TITLE
[Design] PracticeView ScriptView 작성

### DIFF
--- a/highpitch.xcodeproj/project.pbxproj
+++ b/highpitch.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		1DED4EEC2AFCA7EE000109B3 /* SpeedFeedbackContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */; };
 		1DED4EF02AFCAAA2000109B3 /* SwiftDataMockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EEF2AFCAAA2000109B3 /* SwiftDataMockManager.swift */; };
 		1DED4EF72AFFE4F7000109B3 /* HPArcodianView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EF62AFFE4F7000109B3 /* HPArcodianView.swift */; };
+		1DED4EF92B008725000109B3 /* FeedbackStyleScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EF82B008725000109B3 /* FeedbackStyleScript.swift */; };
 		1DF659902AD594BF00AE5601 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1DF6598F2AD594BF00AE5601 /* Assets.xcassets */; };
 		1DF659942AD594BF00AE5601 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1DF659932AD594BF00AE5601 /* Preview Assets.xcassets */; };
 		1DF6599F2AD594BF00AE5601 /* highpitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF6599E2AD594BF00AE5601 /* highpitchTests.swift */; };
@@ -238,6 +239,7 @@
 		1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFeedbackContent.swift; sourceTree = "<group>"; };
 		1DED4EEF2AFCAAA2000109B3 /* SwiftDataMockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataMockManager.swift; sourceTree = "<group>"; };
 		1DED4EF62AFFE4F7000109B3 /* HPArcodianView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPArcodianView.swift; sourceTree = "<group>"; };
+		1DED4EF82B008725000109B3 /* FeedbackStyleScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackStyleScript.swift; sourceTree = "<group>"; };
 		1DF659862AD594BD00AE5601 /* highpitch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = highpitch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DF6598F2AD594BF00AE5601 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1DF659912AD594BF00AE5601 /* highpitch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = highpitch.entitlements; sourceTree = "<group>"; };
@@ -813,6 +815,7 @@
 				1DED4EE72AFCA7C0000109B3 /* FillerWordFeedbackContent.swift */,
 				1DED4EE92AFCA7D9000109B3 /* EveryFeedbackContent.swift */,
 				1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */,
+				1DED4EF82B008725000109B3 /* FeedbackStyleScript.swift */,
 			);
 			path = FeedbackContent;
 			sourceTree = "<group>";
@@ -1137,6 +1140,7 @@
 				1D09AF9C2ADA6BBB00C1400E /* AudioControllerView.swift in Sources */,
 				1DED4EE32AFCA68B000109B3 /* SpeedAudioIndicator.swift in Sources */,
 				1D09AF832AD9963E00C1400E /* ProjectManager.swift in Sources */,
+				1DED4EF92B008725000109B3 /* FeedbackStyleScript.swift in Sources */,
 				1DF659C82AD5998D00AE5601 /* MenubarExtraView.swift in Sources */,
 				1D58FA292AE2956E00B92B4A /* HPMenu.swift in Sources */,
 				1172F1092AE1442900D6B0B9 /* PracticeSummaryModel.swift in Sources */,

--- a/highpitch.xcodeproj/project.pbxproj
+++ b/highpitch.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		1D0ECD7C2ADE010500B95A74 /* HPTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0ECD7B2ADE010500B95A74 /* HPTooltip.swift */; };
 		1D0ECD7E2ADE05D500B95A74 /* HPStyledLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0ECD7D2ADE05D500B95A74 /* HPStyledLabel.swift */; };
 		1D1EC68C2AFB351800CB72E9 /* SentenceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC68B2AFB351800CB72E9 /* SentenceInfo.swift */; };
+		1D1EC6962AFB6DC500CB72E9 /* PracticeContentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC6952AFB6DC500CB72E9 /* PracticeContentContainer.swift */; };
 		1D30E6252AD6117F00623A58 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D30E6242AD6117F00623A58 /* MediaManager.swift */; };
 		1D30E62C2AD6E88500623A58 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1D30E62B2AD6E88500623A58 /* .swiftlint.yml */; };
 		1D30E62F2AD6EA7500623A58 /* AppleScriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D30E62E2AD6EA7500623A58 /* AppleScriptManager.swift */; };
@@ -182,6 +183,7 @@
 		1D0ECD7B2ADE010500B95A74 /* HPTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPTooltip.swift; sourceTree = "<group>"; };
 		1D0ECD7D2ADE05D500B95A74 /* HPStyledLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPStyledLabel.swift; sourceTree = "<group>"; };
 		1D1EC68B2AFB351800CB72E9 /* SentenceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceInfo.swift; sourceTree = "<group>"; };
+		1D1EC6952AFB6DC500CB72E9 /* PracticeContentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeContentContainer.swift; sourceTree = "<group>"; };
 		1D30E6242AD6117F00623A58 /* MediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManager.swift; sourceTree = "<group>"; };
 		1D30E62B2AD6E88500623A58 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		1D30E62E2AD6EA7500623A58 /* AppleScriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptManager.swift; sourceTree = "<group>"; };
@@ -327,6 +329,7 @@
 		1D09AF642AD989DA00C1400E /* PracticeView */ = {
 			isa = PBXGroup;
 			children = (
+				1D1EC6942AFB6D8900CB72E9 /* v0.2.0 */,
 				1D0467CD2AFA9B06003EF427 /* Popover */,
 				1D0467C62AFA27F3003EF427 /* Sheet */,
 				1D600BA52AF9DCAC001FC5EB /* Store */,
@@ -547,6 +550,14 @@
 				1DB132302AD771A6006711B9 /* KeynoteManager.swift */,
 			);
 			path = ProjectManagers;
+			sourceTree = "<group>";
+		};
+		1D1EC6942AFB6D8900CB72E9 /* v0.2.0 */ = {
+			isa = PBXGroup;
+			children = (
+				1D1EC6952AFB6DC500CB72E9 /* PracticeContentContainer.swift */,
+			);
+			path = v0.2.0;
 			sourceTree = "<group>";
 		};
 		1D30E6162AD59E0C00623A58 /* Models */ = {
@@ -1084,6 +1095,7 @@
 				1D09AFA72ADA78A800C1400E /* UsageTopTierChart.swift in Sources */,
 				1D09AF922ADA34B100C1400E /* ShapeModifier.swift in Sources */,
 				10C7D1FD2ADE12B3008691CD /* TokenData.swift in Sources */,
+				1D1EC6962AFB6DC500CB72E9 /* PracticeContentContainer.swift in Sources */,
 				1D98941F2AE6199000DE57A1 /* PracticeList.swift in Sources */,
 				1D600BA72AF9DCBA001FC5EB /* PracticeViewStore.swift in Sources */,
 				1D09AF6E2AD98B0100C1400E /* NotificationManager.swift in Sources */,

--- a/highpitch.xcodeproj/project.pbxproj
+++ b/highpitch.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		1DED4EEA2AFCA7D9000109B3 /* EveryFeedbackContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EE92AFCA7D9000109B3 /* EveryFeedbackContent.swift */; };
 		1DED4EEC2AFCA7EE000109B3 /* SpeedFeedbackContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */; };
 		1DED4EF02AFCAAA2000109B3 /* SwiftDataMockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EEF2AFCAAA2000109B3 /* SwiftDataMockManager.swift */; };
+		1DED4EF72AFFE4F7000109B3 /* HPArcodianView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EF62AFFE4F7000109B3 /* HPArcodianView.swift */; };
 		1DF659902AD594BF00AE5601 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1DF6598F2AD594BF00AE5601 /* Assets.xcassets */; };
 		1DF659942AD594BF00AE5601 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1DF659932AD594BF00AE5601 /* Preview Assets.xcassets */; };
 		1DF6599F2AD594BF00AE5601 /* highpitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF6599E2AD594BF00AE5601 /* highpitchTests.swift */; };
@@ -236,6 +237,7 @@
 		1DED4EE92AFCA7D9000109B3 /* EveryFeedbackContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EveryFeedbackContent.swift; sourceTree = "<group>"; };
 		1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFeedbackContent.swift; sourceTree = "<group>"; };
 		1DED4EEF2AFCAAA2000109B3 /* SwiftDataMockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataMockManager.swift; sourceTree = "<group>"; };
+		1DED4EF62AFFE4F7000109B3 /* HPArcodianView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPArcodianView.swift; sourceTree = "<group>"; };
 		1DF659862AD594BD00AE5601 /* highpitch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = highpitch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DF6598F2AD594BF00AE5601 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1DF659912AD594BF00AE5601 /* highpitch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = highpitch.entitlements; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 				1D0ECD7D2ADE05D500B95A74 /* HPStyledLabel.swift */,
 				1DBF14532ADE574F00B28CED /* HPSegmentedControl.swift */,
 				1D58FA282AE2956E00B92B4A /* HPMenu.swift */,
+				1DED4EF62AFFE4F7000109B3 /* HPArcodianView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1125,6 +1128,7 @@
 				1D30E6252AD6117F00623A58 /* MediaManager.swift in Sources */,
 				1D1EC6A32AFB98C900CB72E9 /* VideoContainer.swift in Sources */,
 				1142DDED2AF4C7F8003DBE81 /* SlowSentReplay.swift in Sources */,
+				1DED4EF72AFFE4F7000109B3 /* HPArcodianView.swift in Sources */,
 				1D09AF742AD98C0900C1400E /* Date+Extension.swift in Sources */,
 				1DE8B64E2AECDC1200E0746E /* HPLabelStyle.swift in Sources */,
 				10C7D1B02ADCD42F008691CD /* Bundle+Extension.swift in Sources */,

--- a/highpitch.xcodeproj/project.pbxproj
+++ b/highpitch.xcodeproj/project.pbxproj
@@ -61,6 +61,11 @@
 		1D0ECD7E2ADE05D500B95A74 /* HPStyledLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0ECD7D2ADE05D500B95A74 /* HPStyledLabel.swift */; };
 		1D1EC68C2AFB351800CB72E9 /* SentenceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC68B2AFB351800CB72E9 /* SentenceInfo.swift */; };
 		1D1EC6962AFB6DC500CB72E9 /* PracticeContentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC6952AFB6DC500CB72E9 /* PracticeContentContainer.swift */; };
+		1D1EC69A2AFB96E600CB72E9 /* FullScreenVideoContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC6992AFB96E600CB72E9 /* FullScreenVideoContainer.swift */; };
+		1D1EC69C2AFB973400CB72E9 /* SplitViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC69B2AFB973400CB72E9 /* SplitViewContainer.swift */; };
+		1D1EC69F2AFB978900CB72E9 /* VideoControllerContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC69E2AFB978900CB72E9 /* VideoControllerContainer.swift */; };
+		1D1EC6A32AFB98C900CB72E9 /* VideoContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC6A22AFB98C900CB72E9 /* VideoContainer.swift */; };
+		1D1EC6A52AFB990100CB72E9 /* PracticeDetailContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1EC6A42AFB990100CB72E9 /* PracticeDetailContainer.swift */; };
 		1D30E6252AD6117F00623A58 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D30E6242AD6117F00623A58 /* MediaManager.swift */; };
 		1D30E62C2AD6E88500623A58 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1D30E62B2AD6E88500623A58 /* .swiftlint.yml */; };
 		1D30E62F2AD6EA7500623A58 /* AppleScriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D30E62E2AD6EA7500623A58 /* AppleScriptManager.swift */; };
@@ -98,6 +103,12 @@
 		1DE8B64E2AECDC1200E0746E /* HPLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE8B64D2AECDC1200E0746E /* HPLabelStyle.swift */; };
 		1DE8B6512AECECBE00E0746E /* HPLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE8B6502AECECBE00E0746E /* HPLabel.swift */; };
 		1DE8B6532AED1C7B00E0746E /* HPButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE8B6522AED1C7B00E0746E /* HPButtonStyle.swift */; };
+		1DED4EE12AFCA64A000109B3 /* FillerWordAudioIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EE02AFCA64A000109B3 /* FillerWordAudioIndicator.swift */; };
+		1DED4EE32AFCA68B000109B3 /* SpeedAudioIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EE22AFCA68B000109B3 /* SpeedAudioIndicator.swift */; };
+		1DED4EE82AFCA7C0000109B3 /* FillerWordFeedbackContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EE72AFCA7C0000109B3 /* FillerWordFeedbackContent.swift */; };
+		1DED4EEA2AFCA7D9000109B3 /* EveryFeedbackContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EE92AFCA7D9000109B3 /* EveryFeedbackContent.swift */; };
+		1DED4EEC2AFCA7EE000109B3 /* SpeedFeedbackContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */; };
+		1DED4EF02AFCAAA2000109B3 /* SwiftDataMockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DED4EEF2AFCAAA2000109B3 /* SwiftDataMockManager.swift */; };
 		1DF659902AD594BF00AE5601 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1DF6598F2AD594BF00AE5601 /* Assets.xcassets */; };
 		1DF659942AD594BF00AE5601 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1DF659932AD594BF00AE5601 /* Preview Assets.xcassets */; };
 		1DF6599F2AD594BF00AE5601 /* highpitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF6599E2AD594BF00AE5601 /* highpitchTests.swift */; };
@@ -184,6 +195,11 @@
 		1D0ECD7D2ADE05D500B95A74 /* HPStyledLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPStyledLabel.swift; sourceTree = "<group>"; };
 		1D1EC68B2AFB351800CB72E9 /* SentenceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceInfo.swift; sourceTree = "<group>"; };
 		1D1EC6952AFB6DC500CB72E9 /* PracticeContentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeContentContainer.swift; sourceTree = "<group>"; };
+		1D1EC6992AFB96E600CB72E9 /* FullScreenVideoContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenVideoContainer.swift; sourceTree = "<group>"; };
+		1D1EC69B2AFB973400CB72E9 /* SplitViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewContainer.swift; sourceTree = "<group>"; };
+		1D1EC69E2AFB978900CB72E9 /* VideoControllerContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoControllerContainer.swift; sourceTree = "<group>"; };
+		1D1EC6A22AFB98C900CB72E9 /* VideoContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoContainer.swift; sourceTree = "<group>"; };
+		1D1EC6A42AFB990100CB72E9 /* PracticeDetailContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeDetailContainer.swift; sourceTree = "<group>"; };
 		1D30E6242AD6117F00623A58 /* MediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManager.swift; sourceTree = "<group>"; };
 		1D30E62B2AD6E88500623A58 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		1D30E62E2AD6EA7500623A58 /* AppleScriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptManager.swift; sourceTree = "<group>"; };
@@ -214,6 +230,12 @@
 		1DE8B64D2AECDC1200E0746E /* HPLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPLabelStyle.swift; sourceTree = "<group>"; };
 		1DE8B6502AECECBE00E0746E /* HPLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPLabel.swift; sourceTree = "<group>"; };
 		1DE8B6522AED1C7B00E0746E /* HPButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HPButtonStyle.swift; sourceTree = "<group>"; };
+		1DED4EE02AFCA64A000109B3 /* FillerWordAudioIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillerWordAudioIndicator.swift; sourceTree = "<group>"; };
+		1DED4EE22AFCA68B000109B3 /* SpeedAudioIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedAudioIndicator.swift; sourceTree = "<group>"; };
+		1DED4EE72AFCA7C0000109B3 /* FillerWordFeedbackContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillerWordFeedbackContent.swift; sourceTree = "<group>"; };
+		1DED4EE92AFCA7D9000109B3 /* EveryFeedbackContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EveryFeedbackContent.swift; sourceTree = "<group>"; };
+		1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedFeedbackContent.swift; sourceTree = "<group>"; };
+		1DED4EEF2AFCAAA2000109B3 /* SwiftDataMockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataMockManager.swift; sourceTree = "<group>"; };
 		1DF659862AD594BD00AE5601 /* highpitch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = highpitch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DF6598F2AD594BF00AE5601 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1DF659912AD594BF00AE5601 /* highpitch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = highpitch.entitlements; sourceTree = "<group>"; };
@@ -556,8 +578,55 @@
 			isa = PBXGroup;
 			children = (
 				1D1EC6952AFB6DC500CB72E9 /* PracticeContentContainer.swift */,
+				1D1EC6982AFB96D200CB72E9 /* FullScreenVideoContainer */,
+				1D1EC6972AFB96B600CB72E9 /* SplitViewContainer */,
+				1D1EC69D2AFB977600CB72E9 /* VideoControllerContainer */,
 			);
 			path = v0.2.0;
+			sourceTree = "<group>";
+		};
+		1D1EC6972AFB96B600CB72E9 /* SplitViewContainer */ = {
+			isa = PBXGroup;
+			children = (
+				1D1EC69B2AFB973400CB72E9 /* SplitViewContainer.swift */,
+				1D1EC6A02AFB980100CB72E9 /* VideoContainer */,
+				1D1EC6A12AFB983800CB72E9 /* PracticeDetailContainer */,
+			);
+			path = SplitViewContainer;
+			sourceTree = "<group>";
+		};
+		1D1EC6982AFB96D200CB72E9 /* FullScreenVideoContainer */ = {
+			isa = PBXGroup;
+			children = (
+				1D1EC6992AFB96E600CB72E9 /* FullScreenVideoContainer.swift */,
+			);
+			path = FullScreenVideoContainer;
+			sourceTree = "<group>";
+		};
+		1D1EC69D2AFB977600CB72E9 /* VideoControllerContainer */ = {
+			isa = PBXGroup;
+			children = (
+				1DED4EDF2AFCA60D000109B3 /* AudioIndicator */,
+				1D1EC69E2AFB978900CB72E9 /* VideoControllerContainer.swift */,
+			);
+			path = VideoControllerContainer;
+			sourceTree = "<group>";
+		};
+		1D1EC6A02AFB980100CB72E9 /* VideoContainer */ = {
+			isa = PBXGroup;
+			children = (
+				1D1EC6A22AFB98C900CB72E9 /* VideoContainer.swift */,
+			);
+			path = VideoContainer;
+			sourceTree = "<group>";
+		};
+		1D1EC6A12AFB983800CB72E9 /* PracticeDetailContainer */ = {
+			isa = PBXGroup;
+			children = (
+				1DED4EE42AFCA6A6000109B3 /* FeedbackContent */,
+				1D1EC6A42AFB990100CB72E9 /* PracticeDetailContainer.swift */,
+			);
+			path = PracticeDetailContainer;
 			sourceTree = "<group>";
 		};
 		1D30E6162AD59E0C00623A58 /* Models */ = {
@@ -572,6 +641,7 @@
 		1D30E6222AD6113C00623A58 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				1DED4EF12AFCAAB7000109B3 /* TestManagers */,
 				1D1EC6912AFB642000CB72E9 /* ProjectManagers */,
 				1D1EC6902AFB63F700CB72E9 /* SystemManagers */,
 			);
@@ -723,6 +793,33 @@
 				1DE8B6502AECECBE00E0746E /* HPLabel.swift */,
 			);
 			path = HPLabel;
+			sourceTree = "<group>";
+		};
+		1DED4EDF2AFCA60D000109B3 /* AudioIndicator */ = {
+			isa = PBXGroup;
+			children = (
+				1DED4EE02AFCA64A000109B3 /* FillerWordAudioIndicator.swift */,
+				1DED4EE22AFCA68B000109B3 /* SpeedAudioIndicator.swift */,
+			);
+			path = AudioIndicator;
+			sourceTree = "<group>";
+		};
+		1DED4EE42AFCA6A6000109B3 /* FeedbackContent */ = {
+			isa = PBXGroup;
+			children = (
+				1DED4EE72AFCA7C0000109B3 /* FillerWordFeedbackContent.swift */,
+				1DED4EE92AFCA7D9000109B3 /* EveryFeedbackContent.swift */,
+				1DED4EEB2AFCA7EE000109B3 /* SpeedFeedbackContent.swift */,
+			);
+			path = FeedbackContent;
+			sourceTree = "<group>";
+		};
+		1DED4EF12AFCAAB7000109B3 /* TestManagers */ = {
+			isa = PBXGroup;
+			children = (
+				1DED4EEF2AFCAAA2000109B3 /* SwiftDataMockManager.swift */,
+			);
+			path = TestManagers;
 			sourceTree = "<group>";
 		};
 		1DF6597D2AD594BD00AE5601 = {
@@ -1026,6 +1123,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1D30E6252AD6117F00623A58 /* MediaManager.swift in Sources */,
+				1D1EC6A32AFB98C900CB72E9 /* VideoContainer.swift in Sources */,
 				1142DDED2AF4C7F8003DBE81 /* SlowSentReplay.swift in Sources */,
 				1D09AF742AD98C0900C1400E /* Date+Extension.swift in Sources */,
 				1DE8B64E2AECDC1200E0746E /* HPLabelStyle.swift in Sources */,
@@ -1033,6 +1131,7 @@
 				1DB132312AD771A6006711B9 /* KeynoteManager.swift in Sources */,
 				11EF719F2ADEAA2C00D991E6 /* FastSentReplay.swift in Sources */,
 				1D09AF9C2ADA6BBB00C1400E /* AudioControllerView.swift in Sources */,
+				1DED4EE32AFCA68B000109B3 /* SpeedAudioIndicator.swift in Sources */,
 				1D09AF832AD9963E00C1400E /* ProjectManager.swift in Sources */,
 				1DF659C82AD5998D00AE5601 /* MenubarExtraView.swift in Sources */,
 				1D58FA292AE2956E00B92B4A /* HPMenu.swift in Sources */,
@@ -1048,6 +1147,7 @@
 				1D0467C82AFA281D003EF427 /* FillerWordSheet.swift in Sources */,
 				1DE8B6532AED1C7B00E0746E /* HPButtonStyle.swift in Sources */,
 				1D0467CF2AFA9B2A003EF427 /* PracticeInfoPopover.swift in Sources */,
+				1DED4EE12AFCA64A000109B3 /* FillerWordAudioIndicator.swift in Sources */,
 				1D09AF682AD98A1700C1400E /* ProjectView.swift in Sources */,
 				1DDB9D502AF75529001CA7CC /* GAManager.swift in Sources */,
 				1D09AFA52ADA785100C1400E /* UsagePercentChart.swift in Sources */,
@@ -1055,6 +1155,7 @@
 				1D09AF882ADA267500C1400E /* Colors.swift in Sources */,
 				11EF719B2ADADBA400D991E6 /* FillerWordList.swift in Sources */,
 				1D600BAB2AF9DDBD001FC5EB /* RequestAudioPermissionPopover.swift in Sources */,
+				1DED4EE82AFCA7C0000109B3 /* FillerWordFeedbackContent.swift in Sources */,
 				1D0467D62AFB114B003EF427 /* SentenceCell.swift in Sources */,
 				1172F1032AE1326000D6B0B9 /* WordModel.swift in Sources */,
 				1172F1072AE1335100D6B0B9 /* SentenceModel.swift in Sources */,
@@ -1065,6 +1166,7 @@
 				1D09AF7C2AD9954000C1400E /* ProjectNavigationLinkView.swift in Sources */,
 				1DE8B6512AECECBE00E0746E /* HPLabel.swift in Sources */,
 				11EF719D2ADE3F0E00D991E6 /* FillerWordDetail.swift in Sources */,
+				1DED4EEA2AFCA7D9000109B3 /* EveryFeedbackContent.swift in Sources */,
 				1DBF145C2AE0A75700B28CED /* PracticeManager.swift in Sources */,
 				1D09AF9E2ADA765000C1400E /* FeedbackChartView.swift in Sources */,
 				1DBF14642AE1391F00B28CED /* MenubarExtraContent.swift in Sources */,
@@ -1074,7 +1176,10 @@
 				1D09AF8A2ADA26B600C1400E /* Color+Extension.swift in Sources */,
 				118D56392AE15572003072E9 /* FillerWordModel.swift in Sources */,
 				1D9894212AE61A4B00DE57A1 /* PracticeListCell.swift in Sources */,
+				1D1EC69C2AFB973400CB72E9 /* SplitViewContainer.swift in Sources */,
+				1D1EC6A52AFB990100CB72E9 /* PracticeDetailContainer.swift in Sources */,
 				1DF659C52AD5992C00AE5601 /* SettingsView.swift in Sources */,
+				1D1EC69F2AFB978900CB72E9 /* VideoControllerContainer.swift in Sources */,
 				1D1EC68C2AFB351800CB72E9 /* SentenceInfo.swift in Sources */,
 				43556EAB2ADE80A900B3E7B7 /* UtteranceModel.swift in Sources */,
 				1DDB9D072AF2B1D4001CA7CC /* SystemManager.swift in Sources */,
@@ -1083,10 +1188,12 @@
 				1D7A3ED82ADC0FBD0084E962 /* OpendKeynote.swift in Sources */,
 				107035002AF258390097A685 /* GeneralSettingView.swift in Sources */,
 				1DBF14612AE1380D00B28CED /* MenubarExtraHeader.swift in Sources */,
+				1DED4EF02AFCAAA2000109B3 /* SwiftDataMockManager.swift in Sources */,
 				1D0ECD7A2ADDA35400B95A74 /* HPTopToolbar.swift in Sources */,
 				1D09AFA02ADA767000C1400E /* ScriptView.swift in Sources */,
 				1D0ECD752ADD9B3D00B95A74 /* Space.swift in Sources */,
 				1DBF14512ADE1DC100B28CED /* LabelModifier.swift in Sources */,
+				1DED4EEC2AFCA7EE000109B3 /* SpeedFeedbackContent.swift in Sources */,
 				1D09AF712AD98BB700C1400E /* SpeechRecognizerManager.swift in Sources */,
 				1D09AF972ADA681500C1400E /* PracticesTabItem.swift in Sources */,
 				1D09AFA92ADA78DF00C1400E /* SpeedAverageChart.swift in Sources */,
@@ -1108,6 +1215,7 @@
 				1DDB9D0A2AF3147B001CA7CC /* OverlayView.swift in Sources */,
 				107034FE2AF258070097A685 /* FeedbackSettingView.swift in Sources */,
 				1D0467D42AFAA404003EF427 /* FillerWordDetailCell.swift in Sources */,
+				1D1EC69A2AFB96E600CB72E9 /* FullScreenVideoContainer.swift in Sources */,
 				1D09AFB12ADAD08E00C1400E /* FileSystemManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/highpitch.xcodeproj/project.pbxproj
+++ b/highpitch.xcodeproj/project.pbxproj
@@ -1254,6 +1254,164 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1DED4EF22AFF749E000109B3 /* Preview */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = PREVIEW;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Preview;
+		};
+		1DED4EF32AFF749E000109B3 /* Preview */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = highpitch/App/highpitch.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"highpitch/App/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = V7Y39HNV38;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = V7Y39HNV38;
+				ENABLE_HARDENED_RUNTIME = YES;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = highpitch/App/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = highpitch;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "highpitch는 음성 녹음을 통해 사용자의 음성을 분석하고 개선된 서비스를 제공합니다.";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.windup.highpitch;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "highpitch ios debug";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "highpitch mac debug";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Preview;
+		};
+		1DED4EF42AFF749E000109B3 /* Preview */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = V7Y39HNV38;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = yuncoffee.highpitchTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/highpitch.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/highpitch";
+			};
+			name = Preview;
+		};
+		1DED4EF52AFF749E000109B3 /* Preview */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = V7Y39HNV38;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = yuncoffee.highpitchUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = highpitch;
+			};
+			name = Preview;
+		};
 		1DF659AC2AD594BF00AE5601 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1569,6 +1727,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DF659AC2AD594BF00AE5601 /* Debug */,
+				1DED4EF22AFF749E000109B3 /* Preview */,
 				1DF659AD2AD594BF00AE5601 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1578,6 +1737,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DF659AF2AD594BF00AE5601 /* Debug */,
+				1DED4EF32AFF749E000109B3 /* Preview */,
 				1DF659B02AD594BF00AE5601 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1587,6 +1747,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DF659B22AD594BF00AE5601 /* Debug */,
+				1DED4EF42AFF749E000109B3 /* Preview */,
 				1DF659B32AD594BF00AE5601 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1596,6 +1757,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1DF659B52AD594BF00AE5601 /* Debug */,
+				1DED4EF52AFF749E000109B3 /* Preview */,
 				1DF659B62AD594BF00AE5601 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/highpitch.xcodeproj/xcshareddata/xcschemes/highpitch_preview.xcscheme
+++ b/highpitch.xcodeproj/xcshareddata/xcschemes/highpitch_preview.xcscheme
@@ -23,38 +23,14 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Preview"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1DF659992AD594BF00AE5601"
-               BuildableName = "highpitchTests.xctest"
-               BlueprintName = "highpitchTests"
-               ReferencedContainer = "container:highpitch.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1DF659A32AD594BF00AE5601"
-               BuildableName = "highpitchUITests.xctest"
-               BlueprintName = "highpitchUITests"
-               ReferencedContainer = "container:highpitch.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Preview"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -73,16 +49,6 @@
             ReferencedContainer = "container:highpitch.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-FIRAnalyticsDebugEnabled"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-FIRDebugEnabled"
-            isEnabled = "NO">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/highpitch/APIs/ReturnZero/ReturnzeroAPIV2.swift
+++ b/highpitch/APIs/ReturnZero/ReturnzeroAPIV2.swift
@@ -1,8 +1,6 @@
 import Foundation
 import Security
 
-
-
 struct ReturnzeroAPIV2 {
     let keyChainManager = KeychainManager()
     let returnZero_CLIENT_ID = Bundle().returnZeroClientId
@@ -43,7 +41,7 @@ struct ReturnzeroAPIV2 {
     
     private func isAuth() async throws -> String {
         // MARK: 여기다!!!!!!!!여기다!!!!!!!!여기다!!!!!!!!여기다!!!!!!!!여기다!!!!!!!!
-        do{
+        do {
             if let token = try keyChainManager.load(forKey: .rzToken) as? TokenData {
                 if(Date.now.compare(token.expried).rawValue < 0) {
                     return token.token
@@ -54,7 +52,7 @@ struct ReturnzeroAPIV2 {
                 }
             }
             throw RZError.networkErr
-        }catch {
+        } catch {
             print("here")
             let accessToken = try await getToken()
             try keyChainManager.save(data: accessToken, forKey: .rzToken)
@@ -73,7 +71,6 @@ struct ReturnzeroAPIV2 {
         
         // Set your server URL
 
-        
         var request = URLRequest(url: URL(string: tranUrl)!)
         request.httpMethod = "POST"
         

--- a/highpitch/App/HighPitchApp.swift
+++ b/highpitch/App/HighPitchApp.swift
@@ -96,24 +96,24 @@ struct HighpitchApp: App {
     var body: some Scene {
         #if os(macOS)
 //        // MARK: - MainWindow Scene
-        Window("overlay", id: "overlay") {
-            @Bindable var systemManager = SystemManager.shared
-                OverlayView(isActive: $systemManager.isOverlayView1Active)
-            
-        }
-        .windowResizability(.contentSize)
-        Window("overlay2", id: "overlay2") {
-            @Bindable var systemManager = SystemManager.shared
-                OverlayView(isActive: $systemManager.isOverlayView2Active)
-            
-        }
-        .windowResizability(.contentSize)
-        Window("overlay3", id: "overlay3") {
-            @Bindable var systemManager = SystemManager.shared
-                OverlayView(isActive: $systemManager.isOverlayView3Active)
-            
-        }
-        .windowResizability(.contentSize)
+//        Window("overlay", id: "overlay") {
+//            @Bindable var systemManager = SystemManager.shared
+//                OverlayView(isActive: $systemManager.isOverlayView1Active)
+//            
+//        }
+//        .windowResizability(.contentSize)
+//        Window("overlay2", id: "overlay2") {
+//            @Bindable var systemManager = SystemManager.shared
+//                OverlayView(isActive: $systemManager.isOverlayView2Active)
+//            
+//        }
+//        .windowResizability(.contentSize)
+//        Window("overlay3", id: "overlay3") {
+//            @Bindable var systemManager = SystemManager.shared
+//                OverlayView(isActive: $systemManager.isOverlayView3Active)
+//            
+//        }
+//        .windowResizability(.contentSize)
         Window("mainwindow", id: "main") {
             MainWindowView()
                 .environment(appleScriptManager)

--- a/highpitch/App/HighPitchApp.swift
+++ b/highpitch/App/HighPitchApp.swift
@@ -98,28 +98,22 @@ struct HighpitchApp: App {
 //        // MARK: - MainWindow Scene
         Window("overlay", id: "overlay") {
             @Bindable var systemManager = SystemManager.shared
-            if systemManager.isOverlayView1Active {
                 OverlayView(isActive: $systemManager.isOverlayView1Active)
-            }
+            
         }
         .windowResizability(.contentSize)
         Window("overlay2", id: "overlay2") {
             @Bindable var systemManager = SystemManager.shared
-            if systemManager.isOverlayView2Active {
                 OverlayView(isActive: $systemManager.isOverlayView2Active)
-            }
+            
         }
         .windowResizability(.contentSize)
         Window("overlay3", id: "overlay3") {
             @Bindable var systemManager = SystemManager.shared
-            if systemManager.isOverlayView3Active {
                 OverlayView(isActive: $systemManager.isOverlayView3Active)
-            }
+            
         }
         .windowResizability(.contentSize)
-        .defaultPosition(.bottomTrailing)
-        .windowResizability(.contentSize)
-        .commandsRemoved()
         Window("mainwindow", id: "main") {
             MainWindowView()
                 .environment(appleScriptManager)
@@ -224,9 +218,6 @@ struct HighpitchApp: App {
         })
         #endif
     }
-    func updateWeatherData() async {
-        // fetches new weather data and updates app state
-    }
 }
 extension HighpitchApp {
     private func setupInit() {
@@ -306,13 +297,17 @@ extension HighpitchApp {
 
 // MARK: 항상 맨 위에 떠 있는 뷰 (NSPanel)을 추가하기 위한 코드들
 class AppDelegate: NSObject, NSApplicationDelegate {
-    var floatingPanelController: FloatingPanelController?
-
-    func applicationDidFinishLaunching(_ aNotification: Notification) {
-        floatingPanelController = FloatingPanelController()
-        floatingPanelController?.panel?.contentView = NSHostingView(rootView: FloatingView())
-        floatingPanelController?.showPanel(self)
-    }
+//    var floatingPanelController: FloatingPanelController?
+//
+//    func applicationDidFinishLaunching(_ aNotification: Notification) {
+//        floatingPanelController = FloatingPanelController()
+//        floatingPanelController?.panel?.contentView = NSHostingView(rootView: FloatingView())
+//        floatingPanelController?.showPanel(self)
+//    }
+//    func applicationDidUpdate(_ notification: Notification) {
+//        print("\(Date.now.description) zzz")
+//    }
+    
 }
 
 class FloatingPanelController: NSWindowController {

--- a/highpitch/App/HighPitchApp.swift
+++ b/highpitch/App/HighPitchApp.swift
@@ -103,30 +103,30 @@ struct HighpitchApp: App {
     var body: some Scene {
         #if os(macOS)
 //        // MARK: - MainWindow Scene
-//        Window("overlay", id: "overlay") {
-//            @Bindable var systemManager = SystemManager.shared
-//            if systemManager.isOverlayView1Active {
-//                OverlayView(isActive: $systemManager.isOverlayView1Active)
-//            }
-//        }
-//        .windowResizability(.contentSize)
-//        Window("overlay2", id: "overlay2") {
-//            @Bindable var systemManager = SystemManager.shared
-//            if systemManager.isOverlayView2Active {
-//                OverlayView(isActive: $systemManager.isOverlayView2Active)
-//            }
-//        }
-//        .windowResizability(.contentSize)
-//        Window("overlay3", id: "overlay3") {
-//            @Bindable var systemManager = SystemManager.shared
-//            if systemManager.isOverlayView3Active {
-//                OverlayView(isActive: $systemManager.isOverlayView3Active)
-//            }
-//        }
-//        .windowResizability(.contentSize)
-//        .defaultPosition(.bottomTrailing)
-//        .windowResizability(.contentSize)
-//        .commandsRemoved()
+        Window("overlay", id: "overlay") {
+            @Bindable var systemManager = SystemManager.shared
+            if systemManager.isOverlayView1Active {
+                OverlayView(isActive: $systemManager.isOverlayView1Active)
+            }
+        }
+        .windowResizability(.contentSize)
+        Window("overlay2", id: "overlay2") {
+            @Bindable var systemManager = SystemManager.shared
+            if systemManager.isOverlayView2Active {
+                OverlayView(isActive: $systemManager.isOverlayView2Active)
+            }
+        }
+        .windowResizability(.contentSize)
+        Window("overlay3", id: "overlay3") {
+            @Bindable var systemManager = SystemManager.shared
+            if systemManager.isOverlayView3Active {
+                OverlayView(isActive: $systemManager.isOverlayView3Active)
+            }
+        }
+        .windowResizability(.contentSize)
+        .defaultPosition(.bottomTrailing)
+        .windowResizability(.contentSize)
+        .commandsRemoved()
         Window("mainwindow", id: "main") {
             MainWindowView()
                 .environment(appleScriptManager)

--- a/highpitch/DesignSystem/Components/Common/HPArcodianView.swift
+++ b/highpitch/DesignSystem/Components/Common/HPArcodianView.swift
@@ -1,0 +1,83 @@
+//
+//  HPArcodianView.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/12/23.
+//
+
+import SwiftUI
+
+struct HPArcodianView<T: View>: View {
+    var label: String = "컨텐츠 명"
+    var content: () -> T
+    
+    @State
+    var isActive: Bool?
+    
+    @State
+    private var localIsActive = false
+    private let HEADER_HEIGHT = 68.0
+     
+    var body: some View {
+        VStack {
+            header
+            content()
+        }
+        .frame(
+            maxHeight: localIsActive 
+            ? .infinity
+            : HEADER_HEIGHT,
+            alignment: .top
+        )
+        .background(
+            RoundedRectangle(cornerRadius: .HPCornerRadius.large)
+                .stroke(lineWidth: 2)
+                .foregroundStyle(Color.HPComponent.stroke)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.large))
+        .onChange(of: isActive) { _, newValue in
+            if let isActive = newValue {
+                localIsActive = isActive
+            }
+        }
+    }
+}
+
+extension HPArcodianView {
+    @ViewBuilder
+    private var header: some View {
+        // header
+        HStack {
+            Text(label)
+                .systemFont(.caption, weight: .semibold)
+                .foregroundStyle(Color.HPTextStyle.darker)
+            Spacer()
+            HPButton(type: .text, size: .medium, color: .HPTextStyle.base) {
+                withAnimation {
+                    localIsActive.toggle()
+                }
+            } label: { type, size, color, expandable in
+                HPLabel(
+                    content: ("열기", "chevron.down"),
+                    type: type,
+                    size: size,
+                    color: color,
+                    alignStyle: .iconOnly,
+                    expandable: expandable
+                )
+            }
+            .frame(width: ButtonSize.medium.labelSize.height)
+            .rotationEffect(localIsActive ? .degrees(180) : .zero)
+        }
+        .padding(.vertical, .HPSpacing.xsmall)
+        .padding(.horizontal, .HPSpacing.xsmallBetweenSmall)
+    }
+}
+
+#Preview {
+    HPArcodianView {
+        Text("Hello")
+            .border(.blue)
+    }
+    .padding(64)
+}

--- a/highpitch/DesignSystem/Components/Common/HPArcodianView.swift
+++ b/highpitch/DesignSystem/Components/Common/HPArcodianView.swift
@@ -71,6 +71,12 @@ extension HPArcodianView {
         }
         .padding(.vertical, .HPSpacing.xsmall)
         .padding(.horizontal, .HPSpacing.xsmallBetweenSmall)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation {
+                localIsActive.toggle()
+            }
+        }
     }
 }
 

--- a/highpitch/DesignSystem/Components/Core/HPLabel/HPLabel.swift
+++ b/highpitch/DesignSystem/Components/Core/HPLabel/HPLabel.swift
@@ -15,6 +15,7 @@ struct HPLabel: View, StyleEssential, LabelStyleEssential {
     
     var alignStyle: LabelAlignStyle = .textOnly
     var iconSize: CGFloat?
+    var contentColor: Color?
     
     var expandable: Bool = false
     var fontStyle: HPFont = .system(.caption)
@@ -29,6 +30,7 @@ struct HPLabel: View, StyleEssential, LabelStyleEssential {
                 color: color,
                 alignStyle: (content.icon != nil) ? alignStyle : .textOnly,
                 iconSize: iconSize,
+                contentColor: contentColor,
                 expandable: expandable,
                 fontStyle: fontStyle,
                 width: width,

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.swift
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.swift
@@ -109,6 +109,7 @@ extension Color {
     }
 }
 
+// swiftlint disable nesting type_name
 // MARK: - Components
 extension Color {
     /// 특정 컴포넌트용 컬러를 위해 사용되는 네임스페이스
@@ -152,5 +153,13 @@ extension Color {
             private init() {}
             static let background = Color.tagbackground
         }
+        
+        // MARK: - 스타일 정리 필요...
+        struct TimeFeedback {
+            private init() {}
+            static let text = Color.timefeedbacktext
+            static let background = Color.timefeedbackbackground
+        }
     }
 }
+// swiftlint enable nesting type_name

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.swift
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.swift
@@ -85,6 +85,20 @@ extension Color {
         /// #EF5555, 1
         static let base = Color.red500
     }
+    struct HPGreen {
+        private init() {}
+        /// #11B029, 0.5
+        static let light = Color.green300
+        /// #11B029, 1
+        static let base = Color.green500
+    }
+    struct HPOrange {
+        private init() {}
+        /// #FF9500, 0.5
+        static let light = Color.orange300
+        /// #FF9500, 1
+        static let base = Color.orange500
+    }
 }
 
 // MARK: - TextStyle
@@ -159,6 +173,11 @@ extension Color {
             private init() {}
             static let text = Color.timefeedbacktext
             static let background = Color.timefeedbackbackground
+        }
+        
+        struct SpeedFeedback {
+            private init() {}
+            static let background = Color.speedfeedbackbackground
         }
     }
 }

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.swift
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.swift
@@ -16,7 +16,7 @@ extension Color {
         static let dark = Color.primary600
         /// #8B6DFF, 1
         static let base = Color.primary500
-        /// #AD99FF, 1
+        /// #AD99FF, 1 
         static let light = Color.primary400
         /// #D0C5FF, 1
         static let lighter = Color.primary300

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Green/green300.colorset/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Green/green300.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
+          "alpha" : "0.500",
           "blue" : "0x29",
           "green" : "0xB0",
           "red" : "0x11"
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x16",
-          "green" : "0x90",
-          "red" : "0x00"
+          "alpha" : "0.500",
+          "blue" : "0x38",
+          "green" : "0xA5",
+          "red" : "0x24"
         }
       },
       "idiom" : "universal"

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Orange/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Orange/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Orange/orange300.colorset/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Orange/orange300.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x29",
-          "green" : "0xB0",
-          "red" : "0x11"
+          "alpha" : "0.500",
+          "blue" : "0x00",
+          "green" : "0x95",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x16",
-          "green" : "0x90",
-          "red" : "0x00"
+          "alpha" : "0.500",
+          "blue" : "0x00",
+          "green" : "0x95",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Orange/orange500.colorset/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/4_ColorScale/Orange/orange500.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x29",
-          "green" : "0xB0",
-          "red" : "0x11"
+          "blue" : "0x00",
+          "green" : "0x95",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x16",
-          "green" : "0x90",
-          "red" : "0x00"
+          "blue" : "0x00",
+          "green" : "0x82",
+          "red" : "0xDE"
         }
       },
       "idiom" : "universal"

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/SpeedFeedback/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/SpeedFeedback/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/SpeedFeedback/speedfeedbackbackground.colorset/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/SpeedFeedback/speedfeedbackbackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x29",
-          "green" : "0xB0",
-          "red" : "0x11"
+          "blue" : "0xF3",
+          "green" : "0xF8",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x16",
-          "green" : "0x90",
-          "red" : "0x00"
+          "alpha" : "0.250",
+          "blue" : "0x58",
+          "green" : "0x74",
+          "red" : "0x93"
         }
       },
       "idiom" : "universal"

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/TimeFeedback/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/TimeFeedback/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/TimeFeedback/timefeedbackbackground.colorset/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/TimeFeedback/timefeedbackbackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE4",
+          "green" : "0xE5",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.750",
+          "blue" : "0xE4",
+          "green" : "0xE5",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/TimeFeedback/timefeedbacktext.colorset/Contents.json
+++ b/highpitch/DesignSystem/Foundation/Colors/Colors.xcassets/6_Component/TimeFeedback/timefeedbacktext.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x16",
+          "green" : "0x16",
+          "red" : "0xDE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x04",
+          "green" : "0x04",
+          "red" : "0xAF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/highpitch/DesignSystem/Foundation/Layout/Space.swift
+++ b/highpitch/DesignSystem/Foundation/Layout/Space.swift
@@ -43,5 +43,9 @@ extension CGFloat {
         static let xxlarge: CGFloat = 56
         /// rawValue: 64
         static let xxxlarge: CGFloat = 64
+        
+        /// rawValue: 20 - Utils
+        static let xsmallBetweenSmall: CGFloat = 20
+        
     }
 }

--- a/highpitch/DesignSystem/Foundation/Layout/Space.swift
+++ b/highpitch/DesignSystem/Foundation/Layout/Space.swift
@@ -43,6 +43,5 @@ extension CGFloat {
         static let xxlarge: CGFloat = 56
         /// rawValue: 64
         static let xxxlarge: CGFloat = 64
-        
     }
 }

--- a/highpitch/DesignSystem/Foundation/Styles/BaseStyle.swift
+++ b/highpitch/DesignSystem/Foundation/Styles/BaseStyle.swift
@@ -47,7 +47,6 @@ struct ComponentStyle {
         /// cornerRadius: 100
         /// ```
         case round
-        
 //        var cornerRadius: CGFloat {
 //            switch self {
 //            case .block(let radius):

--- a/highpitch/DesignSystem/Foundation/Styles/HPLabelStyle.swift
+++ b/highpitch/DesignSystem/Foundation/Styles/HPLabelStyle.swift
@@ -11,6 +11,7 @@ import SwiftUI
 protocol LabelStyleEssential {
     var alignStyle: LabelAlignStyle { get }
     var iconSize: CGFloat? { get }
+    var contentColor: Color? { get }
 }
 
 enum LabelAlignStyle {
@@ -104,6 +105,7 @@ struct HPLabelStyle: LabelStyle, StyleEssential, LabelStyleEssential {
     
     var alignStyle: LabelAlignStyle = .textOnly
     var iconSize: CGFloat?
+    var contentColor: Color?
     
     var expandable: Bool = false
     var fontStyle: HPFont = .system(.caption)
@@ -136,7 +138,10 @@ struct HPLabelStyle: LabelStyle, StyleEssential, LabelStyleEssential {
                     : .clear
                 )
                 .foregroundColor(
-                    style.fillStyle.isLook(.fill)
+                    contentColor != nil
+                    ?
+                    contentColor
+                    : style.fillStyle.isLook(.fill)
                     ? .HPGray.systemWhite
                     : color
                 )
@@ -175,7 +180,10 @@ struct HPLabelStyle: LabelStyle, StyleEssential, LabelStyleEssential {
                     : .clear
                 )
                 .foregroundColor(
-                    style.fillStyle.isLook(.fill)
+                    contentColor != nil
+                    ?
+                    contentColor
+                    : style.fillStyle.isLook(.fill)
                     ? .HPGray.systemWhite
                     : color
                 )
@@ -209,6 +217,7 @@ struct HPLabelContent: View, StyleConfiguration, LabelStyleEssential {
     var color: Color
     var alignStyle: LabelAlignStyle
     var iconSize: CGFloat?
+    var contentColor: Color?
     
     var body: some View {
         if alignStyle == .iconWithTextVertical {

--- a/highpitch/DesignSystem/Foundation/Styles/HPLabelStyle.swift
+++ b/highpitch/DesignSystem/Foundation/Styles/HPLabelStyle.swift
@@ -199,6 +199,48 @@ struct HPLabelStyle: LabelStyle, StyleEssential, LabelStyleEssential {
                 .clipShape(
                     RoundedRectangle(cornerRadius: style.cornerStyle.cornerRadius)
                 )
+            case .systemDetail(let foundationTypoSystemFont, let foundationTypoSystemFontWeight):
+                HPLabelContent(
+                    configuration: configuration,
+                    type: type,
+                    size: size,
+                    color: color,
+                    alignStyle: alignStyle,
+                    iconSize: iconSize
+                )
+                .systemFont(foundationTypoSystemFont, weight: foundationTypoSystemFontWeight)
+                .padding(.vertical, padding.v)
+                .padding(.horizontal, padding.h)
+                .frame(
+                    minWidth: width,
+                    maxWidth: .infinity,
+                    minHeight: size.height,
+                    maxHeight: expandable ? .infinity : nil)
+                .background(
+                    style.fillStyle.isLook(.fill)
+                    ? color
+                    : .clear
+                )
+                .foregroundColor(
+                    contentColor != nil
+                    ?
+                    contentColor
+                    : style.fillStyle.isLook(.fill)
+                    ? .HPGray.systemWhite
+                    : color
+                )
+                .overlay {
+                    RoundedRectangle(
+                        cornerRadius: style.cornerStyle.cornerRadius)
+                    .stroke(
+                        style.fillStyle.isLook(.text)
+                        ? .clear
+                        : color, lineWidth: 2)
+                    .cornerRadius(style.cornerStyle.cornerRadius)
+                }
+                .clipShape(
+                    RoundedRectangle(cornerRadius: style.cornerStyle.cornerRadius)
+                )
             }
         } else {
             HStack(spacing: .HPSpacing.xxxxsmall) {

--- a/highpitch/DesignSystem/Foundation/Typography/Typography.swift
+++ b/highpitch/DesignSystem/Foundation/Typography/Typography.swift
@@ -58,6 +58,7 @@ struct HPSystemFontModifier: ViewModifier {
 enum HPFont {
     case system(FoundationTypoSystemFont)
     case styled(HPStyledFont)
+    case systemDetail(FoundationTypoSystemFont, FoundationTypoSystemFont.FontWeight)
 }
 
 enum HPStyledFont {

--- a/highpitch/DesignSystem/Foundation/Typography/Typography.swift
+++ b/highpitch/DesignSystem/Foundation/Typography/Typography.swift
@@ -63,6 +63,7 @@ enum HPFont {
 enum HPStyledFont {
     case largeTitleLv
     case labeldButton
+    case detailTimeFeedback
 }
 
 extension HPStyledFont {
@@ -72,6 +73,8 @@ extension HPStyledFont {
             28
         case .labeldButton:
             10
+        case .detailTimeFeedback:
+            12
         }
     }
     var lineHeight: CGFloat {
@@ -79,6 +82,8 @@ extension HPStyledFont {
         case .largeTitleLv:
             ((self.fontSize*1.68) - self.fontSize) / 2
         case .labeldButton:
+            ((self.fontSize*1.48) - self.fontSize) / 2
+        case .detailTimeFeedback:
             ((self.fontSize*1.48) - self.fontSize) / 2
         }
     }
@@ -88,6 +93,8 @@ extension HPStyledFont {
             .bold
         case .labeldButton:
             .semibold
+        case .detailTimeFeedback:
+            .semibold
         }
     }
     var relateTo: Font.TextStyle {
@@ -95,6 +102,8 @@ extension HPStyledFont {
         case .largeTitleLv:
             .largeTitle
         case .labeldButton:
+            .caption2
+        case .detailTimeFeedback:
             .caption2
         }
     }

--- a/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
+++ b/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftData
 
+// swiftlint: disable type_body_length line_length
 @MainActor
 class SwiftDataMockManager {
     static let previewContainer: ModelContainer = {
@@ -67,7 +68,391 @@ class SwiftDataMockManager {
                 message: "이거 기본 시스템 상해서 아니 없어도 이게 이렇게 뜨거든요 고요."
             )
         ],
-        words: [WordModel]
-        summary: PracticeSummaryModel(syllableSum: 0)
+        words: [
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 30,
+                word: "게"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 9,
+                word: "고요."
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 26,
+                word: "기록"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 2,
+                word: "시스템"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 39,
+                word: "좀"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 3,
+                word: "상해서"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 8,
+                word: "뜨거든요"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 5,
+                word: "없어도"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 15,
+                word: "상태를"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 14,
+                word: "중이라"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 37,
+                word: "갈래"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 44,
+                word: "녹음"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 20,
+                word: "번"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 52,
+                word: "왔어."
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 31,
+                word: "뜰"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 13,
+                word: "녹음"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 1,
+                word: "기본"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 23,
+                word: "있을까요?"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 33,
+                word: "몰랐어요."
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 29,
+                word: "저런"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 47,
+                word: "그런가"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 12,
+                word: "식으로"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 48,
+                word: "이게"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 28,
+                word: "기록도"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 43,
+                word: "같아"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 34,
+                word: "죄송해"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 42,
+                word: "것"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 6,
+                word: "이게"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 41,
+                word: "썼던"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 36,
+                word: "게"
+            ),
+            WordModel(
+                isFillerWord: true,
+                sentenceIndex: 0,
+                index: 4,
+                word: "아니"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 40,
+                word: "안"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 27,
+                word: "화면"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 11,
+                word: "이런"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 10,
+                word: "이거"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 32,
+                word: "텐데"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 50,
+                word: "있을"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 21,
+                word: "보여줄"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 24,
+                word: "이게"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 0,
+                word: "이거"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 35,
+                word: "봐"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 49,
+                word: "떠"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 19,
+                word: "두"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 22,
+                word: "이유가"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 18,
+                word: "얘를"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 45,
+                word: "중에"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 0,
+                index: 7,
+                word: "이렇게"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 51,
+                word: "텐어"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 17,
+                word: "있는데"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 1,
+                index: 16,
+                word: "알고"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 2,
+                index: 25,
+                word: "환면"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 38,
+                word: "난"
+            ),
+            WordModel(
+                isFillerWord: false,
+                sentenceIndex: 3,
+                index: 46,
+                word: "와서"
+            )
+        ],
+        sentences: [
+            SentenceModel(
+                index: 3,
+                sentence: "죄송해 봐 게 같래 난 좀 안 썼던 것 같아 녹음 중에 와서 그런가 이게 떠 있을 텐어 왔어.",
+                startAt: 26387,
+                endAt: 45936,
+                epmValue: 101.2839531433833
+            ),
+            SentenceModel(
+                index: 2,
+                sentence: "이게 환면 기록 화면 기록도 저런 게 뜰 텐데 몰랐어요.",
+                startAt: 21013,
+                endAt: 26327,
+                epmValue: 237.10952201731277
+            ),
+            SentenceModel(
+                index: 0,
+                sentence: "이거 기본 시스템 상해서 아니 없어도 이게 이렇게 뜨거든요 고요.",
+                startAt: 2250,
+                endAt: 14753,
+                epmValue: 124.77005518675517
+            ),
+            SentenceModel(
+                index: 1,
+                sentence: "이거 이런 식으로 녹음 중이라 상태를 알고 있는데 얘를 두 번 보여줄 이유가 있을까요?",
+                startAt: 14773,
+                endAt: 20863,
+                epmValue: 344.82758620689657
+            )
+        ],
+//        summary: PracticeSummaryModel()
+        summary: PracticeSummaryModel(
+            syllableSum: 115,
+            durationSum: 43456,
+            wordCount: 53,
+            fillerWordCount: 1,
+            eachFillerWordCount: [
+                FillerWordModel(fillerWord: "아니", count: 1),
+                FillerWordModel(fillerWord: "막", count: 0),
+                FillerWordModel(fillerWord: "뭐였더라", count: 0),
+                FillerWordModel(fillerWord: "그니깐", count: 0),
+                FillerWordModel(fillerWord: "어", count: 0),
+                FillerWordModel(fillerWord: "저기", count: 0),
+                FillerWordModel(fillerWord: "흠", count: 0),
+                FillerWordModel(fillerWord: "봐봐", count: 0),
+                FillerWordModel(fillerWord: "사실은", count: 0),
+                FillerWordModel(fillerWord: "뭔가", count: 0),
+                FillerWordModel(fillerWord: "그러니까", count: 0),
+                FillerWordModel(fillerWord: "뭐지", count: 0),
+                FillerWordModel(fillerWord: "근데", count: 0),
+                FillerWordModel(fillerWord: "약간", count: 0),
+                FillerWordModel(fillerWord: "인제", count: 0),
+                FillerWordModel(fillerWord: "음", count: 0),
+                FillerWordModel(fillerWord: "아", count: 0),
+                FillerWordModel(fillerWord: "뭐", count: 0),
+                FillerWordModel(fillerWord: "뭐였지", count: 0),
+                FillerWordModel(fillerWord: "이제", count: 0),
+                FillerWordModel(fillerWord: "그래서", count: 0)
+            ],
+            fastSentenceIndex: [1],
+            slowSentenceIndex: [],
+            fillerWordPercentage: 1.8867924528301887,
+            epmAverage: 158.78129602356407,
+            level: 5
+        )
     )
 }
+// swiftlint: enable type_body_length line_length

--- a/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
+++ b/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
@@ -1,0 +1,73 @@
+//
+//  SwiftDataMockManager.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/9/23.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+class SwiftDataMockManager {
+    static let previewContainer: ModelContainer = {
+        do {
+            let config = ModelConfiguration(isStoredInMemoryOnly: true)
+            let container = try ModelContainer(for: PracticeModel.self, configurations: config)
+
+            let samplePractice = PracticeModel(
+                practiceName: "Practice1",
+                index: 0,
+                isVisited: false,
+                creatAt: Date.now.description,
+                utterances: [],
+                summary: PracticeSummaryModel()
+            )
+            container.mainContext.insert(samplePractice)
+            
+//            sampleProject.
+//            sampleProject.practices
+            
+//            for i in 1...9 {
+//                let user = User(name: "Example User \(i)")
+//                container.mainContext.insert(user)
+//            }
+
+            return container
+        } catch {
+            fatalError("Failed to create model container for previewing: \(error.localizedDescription)")
+        }
+    }()
+    
+    static let SamplePracticeModel = PracticeModel(
+        practiceName: "첫번째 연습",
+        index: 0,
+        isVisited: false,
+        creatAt: "2023-11-07 20:21:38 GMT+09:00",
+        audioPath: URL(string: "file:///Users/coffee/Library/Containers/com.windup.highpitch/Data/Documents/HighPitch/Audio/20231107202138.m4a"),
+        utterances: [
+            UtteranceModel(
+                startAt: 26387,
+                duration: 19549,
+                message: "죄송해 봐 게 같래 난 좀 안 썼던 것 같아 녹음 중에 와서 그런가 이게 떠 있을 텐어 왔어."
+            ),
+            UtteranceModel(
+                startAt: 21013,
+                duration: 5314,
+                message: "이게 환면 기록 화면 기록도 저런 게 뜰 텐데 몰랐어요."
+            ),
+            UtteranceModel(
+                startAt: 14773,
+                duration: 6090,
+                message: "이거 이런 식으로 녹음 중이라 상태를 알고 있는데 얘를 두 번 보여줄 이유가 있을까요?"
+            ),
+            UtteranceModel(
+                startAt: 2250,
+                duration: 12503,
+                message: "이거 기본 시스템 상해서 아니 없어도 이게 이렇게 뜨거든요 고요."
+            )
+        ],
+        words: [WordModel]
+        summary: PracticeSummaryModel(syllableSum: 0)
+    )
+}

--- a/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
+++ b/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
@@ -25,14 +25,6 @@ class SwiftDataMockManager {
                 summary: PracticeSummaryModel()
             )
             container.mainContext.insert(samplePractice)
-            
-//            sampleProject.
-//            sampleProject.practices
-            
-//            for i in 1...9 {
-//                let user = User(name: "Example User \(i)")
-//                container.mainContext.insert(user)
-//            }
 
             return container
         } catch {
@@ -454,5 +446,8 @@ class SwiftDataMockManager {
             level: 5
         )
     )
+    static var SamplePracticeModelID = {
+        SamplePracticeModel.persistentModelID
+    }
 }
 // swiftlint: enable type_body_length line_length

--- a/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
+++ b/highpitch/Managers/TestManagers/SwiftDataMockManager.swift
@@ -24,7 +24,7 @@ class SwiftDataMockManager {
                 utterances: [],
                 summary: PracticeSummaryModel()
             )
-            container.mainContext.insert(samplePractice)
+            container.mainContext.insert(SamplePracticeModel)
 
             return container
         } catch {
@@ -65,7 +65,7 @@ class SwiftDataMockManager {
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 30,
-                word: "게"
+                word: "게 "
             ),
             WordModel(
                 isFillerWord: false,
@@ -77,67 +77,67 @@ class SwiftDataMockManager {
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 26,
-                word: "기록"
+                word: "기록 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 2,
-                word: "시스템"
+                word: "시스템 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 39,
-                word: "좀"
+                word: "좀 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 3,
-                word: "상해서"
+                word: "상해서 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 8,
-                word: "뜨거든요"
+                word: "뜨거든요 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 5,
-                word: "없어도"
+                word: "없어도 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 15,
-                word: "상태를"
+                word: "상태를 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 14,
-                word: "중이라"
+                word: "중이라 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 37,
-                word: "갈래"
+                word: "갈래 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 44,
-                word: "녹음"
+                word: "녹음 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 20,
-                word: "번"
+                word: "번 "
             ),
             WordModel(
                 isFillerWord: false,
@@ -149,19 +149,19 @@ class SwiftDataMockManager {
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 31,
-                word: "뜰"
+                word: "뜰 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 13,
-                word: "녹음"
+                word: "녹음 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 1,
-                word: "기본"
+                word: "기본 "
             ),
             WordModel(
                 isFillerWord: false,
@@ -179,205 +179,205 @@ class SwiftDataMockManager {
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 29,
-                word: "저런"
+                word: "저런 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 47,
-                word: "그런가"
+                word: "그런가 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 12,
-                word: "식으로"
+                word: "식으로 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 48,
-                word: "이게"
+                word: "이게 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 28,
-                word: "기록도"
+                word: "기록도 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 43,
-                word: "같아"
+                word: "같아 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 34,
-                word: "죄송해"
+                word: "죄송해 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 42,
-                word: "것"
+                word: "것 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 6,
-                word: "이게"
+                word: "이게 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 41,
-                word: "썼던"
+                word: "썼던 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 36,
-                word: "게"
+                word: "게 "
             ),
             WordModel(
                 isFillerWord: true,
                 sentenceIndex: 0,
                 index: 4,
-                word: "아니"
+                word: "아니 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 40,
-                word: "안"
+                word: "안 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 27,
-                word: "화면"
+                word: "화면 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 11,
-                word: "이런"
+                word: "이런 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 10,
-                word: "이거"
+                word: "이거 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 32,
-                word: "텐데"
+                word: "텐데 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 50,
-                word: "있을"
+                word: "있을 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 21,
-                word: "보여줄"
+                word: "보여줄 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 24,
-                word: "이게"
+                word: "이게 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 0,
-                word: "이거"
+                word: "이거 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 35,
-                word: "봐"
+                word: "봐 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 49,
-                word: "떠"
+                word: "떠 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 19,
-                word: "두"
+                word: "두 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 22,
-                word: "이유가"
+                word: "이유가 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 18,
-                word: "얘를"
+                word: "얘를 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 45,
-                word: "중에"
+                word: "중에 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 0,
                 index: 7,
-                word: "이렇게"
+                word: "이렇게 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 51,
-                word: "텐어"
+                word: "텐어 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 17,
-                word: "있는데"
+                word: "있는데 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 1,
                 index: 16,
-                word: "알고"
+                word: "알고 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 2,
                 index: 25,
-                word: "환면"
+                word: "환면 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 38,
-                word: "난"
+                word: "난 "
             ),
             WordModel(
                 isFillerWord: false,
                 sentenceIndex: 3,
                 index: 46,
-                word: "와서"
+                word: "와서 "
             )
         ],
         sentences: [

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/PracticeView.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/PracticeView.swift
@@ -27,6 +27,7 @@ struct PracticeView: View {
                 completion: nil
             )
             PracticeContentContainer()
+                .clipped()
 //            ZStack(alignment: .bottom) {
 //                practiceContentsContainer
 //                if let audioPath = viewStore.practice.audioPath {

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/PracticeView.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/PracticeView.swift
@@ -26,12 +26,13 @@ struct PracticeView: View {
                 subTitle: viewStore.toolbarInfo.subTitle,
                 completion: nil
             )
-            ZStack(alignment: .bottom) {
-                practiceContentsContainer
-                if let audioPath = viewStore.practice.audioPath {
-                    AudioControllerView(audioPlayer: viewStore.mediaManager, audioPath: audioPath)
-                }
-            }
+            PracticeContentContainer()
+//            ZStack(alignment: .bottom) {
+//                practiceContentsContainer
+//                if let audioPath = viewStore.practice.audioPath {
+//                    AudioControllerView(audioPlayer: viewStore.mediaManager, audioPath: audioPath)
+//                }
+//            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.HPGray.systemWhite)

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
@@ -54,6 +54,8 @@ final class PracticeViewStore {
     
     var currentFeedbackViewType: FeedbackViewType = .fillerWord
     
+    let AUDIO_INDICATOR_HEIGHT = 32.0
+    
     // ************* V2 ************* //
     
     init(practice: PracticeModel, mediaManager: MediaManager) {

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 /**
  PracticeView의 상태를 관리하기 위한 상태저장소
@@ -19,6 +20,41 @@ final class PracticeViewStore {
     var toolbarInfo: (title: String, subTitle: String) = (title: "", subTitle: "")
     /// 현재 선택된 문장의 인덱스
     var nowSentence = 0
+    
+    // ************* V2 ************* //
+    
+    var isFullScreenVideoVisible = false {
+        didSet {
+            if isFullScreenVideoVisible {
+                isFullScreenTransition = true
+            }
+        }
+    }
+    
+    var isFullScreenTransition = false {
+        didSet {
+            if !isFullScreenVideoActive {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.isFullScreenVideoActive = true
+                }
+            }
+        }
+    }
+    
+    var isFullScreenVideoActive = true {
+        didSet {
+            if !isFullScreenVideoActive {
+                isFullScreenTransition = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    self.isFullScreenVideoVisible = false
+                }
+            }
+        }
+    }
+    
+    var currentFeedbackViewType: FeedbackViewType = .fillerWord
+    
+    // ************* V2 ************* //
     
     init(practice: PracticeModel, mediaManager: MediaManager) {
         self.practice = practice
@@ -68,7 +104,39 @@ extension PracticeViewStore {
     }
 }
 
-// MARK: - UsageTopTierChart
+// MARK: - V2
 extension PracticeViewStore {
+    // MARK: Practice이 보여주는 Feedback 종류에 따라 다른 처리를 하기 위함
+}
+
+enum FeedbackViewType {
+    case every
+    case fillerWord
+    case speed
+}
+
+extension FeedbackViewType {
+    @ViewBuilder
+    var audioIndicator: some View {
+        switch self {
+        case .every:
+            EmptyView()
+        case .fillerWord:
+            FillerWordAudioIndicator()
+        case .speed:
+            SpeedAudioIndicator()
+        }
+    }
     
+    @ViewBuilder
+    var feedbackContent: some View {
+        switch self {
+        case .every:
+            EveryFeedbackContent()
+        case .fillerWord:
+            FillerWordFeedbackContent()
+        case .speed:
+            SpeedFeedbackContent()
+        }
+    }
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
@@ -56,7 +56,7 @@ final class PracticeViewStore {
     
     let AUDIO_INDICATOR_HEIGHT = 32.0
     var SCRIPT_CONTAINER_WIDTH: CGFloat {
-        self.currentFeedbackViewType == .every ? 320.0 : 280.0
+        self.currentFeedbackViewType == .every ? 320.0 : 276.0
     }
     // ************* V2 ************* //
     

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
@@ -111,13 +111,13 @@ extension PracticeViewStore {
     // MARK: Practice이 보여주는 Feedback 종류에 따라 다른 처리를 하기 위함
 }
 
-enum FeedbackViewType {
-    case every
-    case fillerWord
-    case speed
+enum FeedbackViewType: String, CaseIterable {
+    case every = "전체 보기"
+    case fillerWord = "습관어"
+    case speed = "말 빠르기"
 }
 
-extension FeedbackViewType {
+extension FeedbackViewType {    
     @ViewBuilder
     var audioIndicator: some View {
         switch self {

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/Store/PracticeViewStore.swift
@@ -55,7 +55,9 @@ final class PracticeViewStore {
     var currentFeedbackViewType: FeedbackViewType = .fillerWord
     
     let AUDIO_INDICATOR_HEIGHT = 32.0
-    
+    var SCRIPT_CONTAINER_WIDTH: CGFloat {
+        self.currentFeedbackViewType == .every ? 320.0 : 280.0
+    }
     // ************* V2 ************* //
     
     init(practice: PracticeModel, mediaManager: MediaManager) {
@@ -103,6 +105,18 @@ extension PracticeViewStore {
     
     func hasFillerWord() -> Bool {
         practice.summary.fillerWordCount > 0
+    }
+    
+    func getContainsWords(sentenceIndex: Int) -> [WordModel] {
+        practice.words
+            .filter({ $0.sentenceIndex == sentenceIndex })
+            .sorted(by: { $0.index < $1.index })
+    }
+    func isFastSentence(sentenceIndex: Int) -> Bool {
+        practice.summary.fastSentenceIndex.contains(sentenceIndex)
+    }
+    func isSlowSentence(sentenceIndex: Int) -> Bool {
+        practice.summary.slowSentenceIndex.contains(sentenceIndex)
     }
 }
 

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/FullScreenVideoContainer/FullScreenVideoContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/FullScreenVideoContainer/FullScreenVideoContainer.swift
@@ -1,0 +1,82 @@
+//
+//  FullScreenVideoContainer.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/8/23.
+//
+
+import SwiftUI
+
+struct FullScreenVideoContainer: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+    @State
+    private var isFullScreenVideoHover = false
+    
+    private let INDICATOR_HEIGHT = 32.0
+    
+    var body: some View {
+        GeometryReader(content: { geometry in
+            ZStack(alignment: .topLeading) {
+                /// video
+                VStack {
+                    Text("Video")
+                        .frame(maxWidth: geometry.size.width, maxHeight: .infinity)
+                        .background(Color.brown)
+                }
+                .offset(
+                    x: 0,
+                    y: viewStore.isFullScreenTransition ? 0 : geometry.size.height / 2 - 150
+                )
+                VStack {
+                    Text("Title")
+                    Text("subTitle")
+                }
+                .frame(maxWidth: .infinity, maxHeight: 64, alignment: .topLeading)
+                .background(Color.purple)
+                .offset(y: viewStore.isFullScreenTransition && isFullScreenVideoHover
+                        ? .zero
+                        : -64
+                )
+                .opacity(viewStore.isFullScreenTransition ? 1 : 0)
+                /// footer
+                HStack {
+                    Text("토글")
+                    Text("토글토글")
+                    Text("토글토글토글")
+                    Text("전체화면")
+                        .onTapGesture {
+                            withAnimation {
+                                viewStore.isFullScreenVideoActive = false
+                            }
+                        }
+                }
+                .frame(maxWidth: .infinity, maxHeight: 56)
+                .background(Color.blue)
+                .offset(y: viewStore.isFullScreenTransition && isFullScreenVideoHover
+                        ? geometry.size.height - (56 + INDICATOR_HEIGHT)
+                        : geometry.size.height - INDICATOR_HEIGHT
+                )
+                .opacity(viewStore.isFullScreenTransition ? 1 : 0)
+                .onTapGesture {
+                    print("HELL?O?")
+                }
+            }
+            .frame(
+                maxWidth: viewStore.isFullScreenTransition ? .infinity : 480,
+                maxHeight: viewStore.isFullScreenTransition ? .infinity : 300
+            )
+            .onHover { hovering in
+                withAnimation {
+                    isFullScreenVideoHover = hovering
+                }
+            }
+        })
+        .zIndex(viewStore.isFullScreenVideoVisible ? 1 : 0)
+    }
+}
+
+#Preview {
+    FullScreenVideoContainer()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
@@ -10,187 +10,16 @@ import SwiftUI
 struct PracticeContentContainer: View {
     @Environment(PracticeViewStore.self)
     var viewStore
-    
-    @State
-    var isFullScreenVideoVisible = false {
-        didSet {
-            if isFullScreenVideoVisible {
-                isFullScreenTransition = true
-            }
-        }
-    }
-    
-    @State
-    var isFullScreenTransition = false {
-        didSet {
-            if !isFullScreenVideoActive {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    isFullScreenVideoActive = true
-                }
-            }
-        }
-    }
-    
-    @State
-    var isFullScreenVideoActive = true {
-        didSet {
-            if !isFullScreenVideoActive {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                    isFullScreenVideoVisible = false
-                }
-            }
-        }
-    }
-    
-    @State
-    var isFullScreenVideoHover = false
-    
-    private let PRACTICE_DETAIL_VIEW_WIDTH = 440.0
-    private let INDICATOR_HEIGHT = 32.0
-    
+
     var body: some View {
         ZStack(alignment: .bottom) {
             ZStack {
-                fullScreenVideoContainer
-                splitViewContainer
+                FullScreenVideoContainer()
+                SplitViewContainer()
             }
             .padding(.bottom, .HPSpacing.xxxlarge)
-            videoControllerContainer
+            VideoControllerContainer()
         }
-    }
-}
-
-extension PracticeContentContainer {
-    @ViewBuilder
-    private var fullScreenVideoContainer: some View {
-        GeometryReader(content: { geometry in
-            ZStack(alignment: .topLeading) {
-                /// video
-                VStack {
-                    Text("Video")
-                        .frame(maxWidth: geometry.size.width, maxHeight: .infinity)
-                        .background(Color.brown)
-                }
-                .offset(
-                    x: 0,
-                    y: isFullScreenTransition ? 0 : geometry.size.height / 2 - 150
-                )
-                VStack {
-                    Text("Title")
-                    Text("subTitle")
-                }
-                .frame(maxWidth: .infinity, maxHeight: 64, alignment: .topLeading)
-                .background(Color.purple)
-                .offset(y: isFullScreenTransition && isFullScreenVideoHover
-                        ? .zero
-                        : -64
-                )
-                /// footer
-                HStack {
-                    Text("토글")
-                    Text("토글토글")
-                    Text("토글토글토글")
-                    Text("전체화면")
-                        .onTapGesture {
-                            withAnimation {
-                                isFullScreenVideoActive = false
-                                isFullScreenTransition = false
-                            }
-                        }
-                }
-                .frame(maxWidth: .infinity, maxHeight: 56)
-                .background(Color.blue)
-                .offset(y: isFullScreenTransition && isFullScreenVideoHover
-                        ? geometry.size.height - (56 + INDICATOR_HEIGHT)
-                        : geometry.size.height - INDICATOR_HEIGHT
-                )
-                .onTapGesture {
-                    print("HELL?O?")
-                }
-            }
-            .frame(
-                maxWidth: isFullScreenTransition ? .infinity : 480,
-                maxHeight: isFullScreenTransition ? .infinity : 300
-            )
-            .onHover { hovering in
-                withAnimation {
-                    isFullScreenVideoHover = hovering
-                }
-            }
-        })
-        .zIndex(isFullScreenVideoVisible ? 1 : 0)
-    }
-    
-    @ViewBuilder
-    private var splitViewContainer: some View {
-        HStack(spacing: .zero) {
-            VStack {
-                VStack {
-                    Text("연습날짜")
-                    Text("연습 타이틀")
-                    HStack {
-                        Text("목표시간")
-                        Text("초과시간")
-                    }
-                }
-                VStack {
-                    Text("Video Active")
-                        .onTapGesture {
-                            withAnimation {
-                                isFullScreenVideoVisible = true
-                            }
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: 200)
-                        .background(Color.gray)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.orange)
-            VStack {
-                HStack {
-                    HStack {
-                        Text("전체보기")
-                        Text("습관어")
-                        Text("말 빠르기")
-                    }
-                    Text("리포트 보기")
-                }
-                /// 차트 컨테이너
-                VStack {
-                    
-                }
-                /// 스크립트 컨테이너
-                VStack {
-                    
-                }
-            }
-            .frame(
-                minWidth: PRACTICE_DETAIL_VIEW_WIDTH,
-                maxWidth: PRACTICE_DETAIL_VIEW_WIDTH,
-                maxHeight: .infinity
-            )
-            .background(Color.green)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .zIndex(isFullScreenVideoVisible ? 0 : 1)
-    }
-    
-    @ViewBuilder
-    private var videoControllerContainer: some View {
-        VStack(spacing: .zero) {
-            HStack {
-                Text("Indicator")
-            }
-            .frame(maxWidth:.infinity, maxHeight: 32)
-            .background(Color.yellow)
-            HStack {
-                Text("AudioController")
-            }
-            .frame(maxWidth:.infinity, maxHeight: 64)
-            .background(Color.red)
-        }
-        
     }
 }
 
@@ -200,7 +29,7 @@ extension PracticeContentContainer {
         .environment(
             PracticeViewStore(
                 practice: PracticeModel(
-                    practiceName: "",
+                    practiceName: "Name",
                     index: 0,
                     isVisited: false,
                     creatAt: "",

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
@@ -6,11 +6,20 @@
 //
 
 import SwiftUI
+#if PREVIEW
+import SwiftData
+#endif
 
 struct PracticeContentContainer: View {
     @Environment(PracticeViewStore.self)
     var viewStore
-
+    
+#if PREVIEW
+    // MARK: - MockData
+    @Query(sort: \PracticeModel.creatAt)
+    var practices: [PracticeModel]
+#endif
+    
     var body: some View {
         ZStack(alignment: .bottom) {
             ZStack {
@@ -20,23 +29,31 @@ struct PracticeContentContainer: View {
             .padding(.bottom, .HPSpacing.xxxlarge)
             VideoControllerContainer()
         }
+        .onAppear {
+            // MARK: - Add MockData
+#if PREVIEW
+            if let sample = practices.first {
+                viewStore.practice = sample
+            }
+#endif
+        }
     }
 }
 
 #Preview {
-    PracticeContentContainer()
+    let modelContainer = SwiftDataMockManager.previewContainer
+    
+    return PracticeContentContainer()
+        .modelContainer(modelContainer)
+        .environment(PracticeViewStore(
+            practice: PracticeModel(
+                practiceName: "",
+                index: 0,
+                isVisited: false,
+                creatAt: "",
+                utterances: [],
+                summary: PracticeSummaryModel()
+            ),
+            mediaManager: MediaManager()))
         .frame(width: 1000, height: 640)
-        .environment(
-            PracticeViewStore(
-                practice: PracticeModel(
-                    practiceName: "Name",
-                    index: 0,
-                    isVisited: false,
-                    creatAt: "",
-                    utterances: [],
-                    summary: PracticeSummaryModel()
-                ),
-                mediaManager: MediaManager()
-            )
-        )
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
@@ -1,0 +1,213 @@
+//
+//  PracticeContentContainer.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/8/23.
+//
+
+import SwiftUI
+
+struct PracticeContentContainer: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+    @State
+    var isFullScreenVideoVisible = false {
+        didSet {
+            if isFullScreenVideoVisible {
+                isFullScreenTransition = true
+            }
+        }
+    }
+    
+    @State
+    var isFullScreenTransition = false {
+        didSet {
+            if !isFullScreenVideoActive {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    isFullScreenVideoActive = true
+                }
+            }
+        }
+    }
+    
+    @State
+    var isFullScreenVideoActive = true {
+        didSet {
+            if !isFullScreenVideoActive {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    isFullScreenVideoVisible = false
+                }
+            }
+        }
+    }
+    
+    @State
+    var isFullScreenVideoHover = false
+    
+    private let PRACTICE_DETAIL_VIEW_WIDTH = 440.0
+    private let INDICATOR_HEIGHT = 32.0
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            ZStack {
+                fullScreenVideoContainer
+                splitViewContainer
+            }
+            .padding(.bottom, .HPSpacing.xxxlarge)
+            videoControllerContainer
+        }
+    }
+}
+
+extension PracticeContentContainer {
+    @ViewBuilder
+    private var fullScreenVideoContainer: some View {
+        GeometryReader(content: { geometry in
+            ZStack(alignment: .topLeading) {
+                /// video
+                VStack {
+                    Text("Video")
+                        .frame(maxWidth: geometry.size.width, maxHeight: .infinity)
+                        .background(Color.brown)
+                }
+                .offset(
+                    x: 0,
+                    y: isFullScreenTransition ? 0 : geometry.size.height / 2 - 150
+                )
+                VStack {
+                    Text("Title")
+                    Text("subTitle")
+                }
+                .frame(maxWidth: .infinity, maxHeight: 64, alignment: .topLeading)
+                .background(Color.purple)
+                .offset(y: isFullScreenTransition && isFullScreenVideoHover
+                        ? .zero
+                        : -64
+                )
+                /// footer
+                HStack {
+                    Text("토글")
+                    Text("토글토글")
+                    Text("토글토글토글")
+                    Text("전체화면")
+                        .onTapGesture {
+                            withAnimation {
+                                isFullScreenVideoActive = false
+                                isFullScreenTransition = false
+                            }
+                        }
+                }
+                .frame(maxWidth: .infinity, maxHeight: 56)
+                .background(Color.blue)
+                .offset(y: isFullScreenTransition && isFullScreenVideoHover
+                        ? geometry.size.height - (56 + INDICATOR_HEIGHT)
+                        : geometry.size.height - INDICATOR_HEIGHT
+                )
+                .onTapGesture {
+                    print("HELL?O?")
+                }
+            }
+            .frame(
+                maxWidth: isFullScreenTransition ? .infinity : 480,
+                maxHeight: isFullScreenTransition ? .infinity : 300
+            )
+            .onHover { hovering in
+                withAnimation {
+                    isFullScreenVideoHover = hovering
+                }
+            }
+        })
+        .zIndex(isFullScreenVideoVisible ? 1 : 0)
+    }
+    
+    @ViewBuilder
+    private var splitViewContainer: some View {
+        HStack(spacing: .zero) {
+            VStack {
+                VStack {
+                    Text("연습날짜")
+                    Text("연습 타이틀")
+                    HStack {
+                        Text("목표시간")
+                        Text("초과시간")
+                    }
+                }
+                VStack {
+                    Text("Video Active")
+                        .onTapGesture {
+                            withAnimation {
+                                isFullScreenVideoVisible = true
+                            }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: 200)
+                        .background(Color.gray)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.orange)
+            VStack {
+                HStack {
+                    HStack {
+                        Text("전체보기")
+                        Text("습관어")
+                        Text("말 빠르기")
+                    }
+                    Text("리포트 보기")
+                }
+                /// 차트 컨테이너
+                VStack {
+                    
+                }
+                /// 스크립트 컨테이너
+                VStack {
+                    
+                }
+            }
+            .frame(
+                minWidth: PRACTICE_DETAIL_VIEW_WIDTH,
+                maxWidth: PRACTICE_DETAIL_VIEW_WIDTH,
+                maxHeight: .infinity
+            )
+            .background(Color.green)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .zIndex(isFullScreenVideoVisible ? 0 : 1)
+    }
+    
+    @ViewBuilder
+    private var videoControllerContainer: some View {
+        VStack(spacing: .zero) {
+            HStack {
+                Text("Indicator")
+            }
+            .frame(maxWidth:.infinity, maxHeight: 32)
+            .background(Color.yellow)
+            HStack {
+                Text("AudioController")
+            }
+            .frame(maxWidth:.infinity, maxHeight: 64)
+            .background(Color.red)
+        }
+        
+    }
+}
+
+#Preview {
+    PracticeContentContainer()
+        .frame(width: 1000, height: 640)
+        .environment(
+            PracticeViewStore(
+                practice: PracticeModel(
+                    practiceName: "",
+                    index: 0,
+                    isVisited: false,
+                    creatAt: "",
+                    utterances: [],
+                    summary: PracticeSummaryModel()
+                ),
+                mediaManager: MediaManager()
+            )
+        )
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct EveryFeedbackContent: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("EveryFeedback")
     }
 }
 

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
@@ -1,0 +1,18 @@
+//
+//  EveryFeedbackContent.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/9/23.
+//
+
+import SwiftUI
+
+struct EveryFeedbackContent: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    EveryFeedbackContent()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
@@ -6,13 +6,177 @@
 //
 
 import SwiftUI
+#if PREVIEW
+import SwiftData
+#endif
 
 struct EveryFeedbackContent: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+#if PREVIEW
+    // MARK: - MockData
+    @Query(sort: \PracticeModel.creatAt)
+    var practices: [PracticeModel]
+#endif
+    
     var body: some View {
-        Text("EveryFeedback")
+        ScrollView {
+            ScrollViewReader { scrollViewProxy in
+                VStack(alignment:. leading, spacing: .zero) {
+                    let sentences = viewStore.getSortedSentences()
+                    ForEach(sentences) { sentence in
+                        let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+                        if let startAt = words.first?.index, let endAt = words.last?.index {
+                            ScriptCell(
+                                words: words,
+                                startAt: startAt,
+                                endAt: endAt,
+                                containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                                isFastSentence: viewStore.isFastSentence(sentenceIndex: sentence.index),
+                                isSlowSentence: viewStore.isSlowSentence(sentenceIndex: sentence.index),
+                                nowSentece: viewStore.nowSentence,
+                                sentenceIndex: sentence.index) { sentenceIndex in
+                                    print(sentenceIndex)
+                                    viewStore.nowSentence = sentenceIndex
+                                }
+                                .id(sentence.index)
+                                .padding(.bottom, .HPSpacing.xxxxsmall)
+                        }
+                    }
+                }
+                .frame(
+                    minWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                    maxWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                    maxHeight:.infinity,
+                    alignment: .topLeading
+                )
+                .padding(.bottom, .HPSpacing.xxxlarge + .HPSpacing.xxxsmall)
+                .padding(.horizontal, .HPSpacing.medium)
+                .onChange(of: viewStore.nowSentence) { _, newValue in
+                    withAnimation {
+                        scrollViewProxy.scrollTo(newValue, anchor: .center)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            // MARK: - Add MockData
+#if PREVIEW
+            if let sample = practices.first {
+                viewStore.practice = sample
+            }
+#endif
+        }
+        
+    }
+}
+
+extension EveryFeedbackContent {
+    struct ScriptCell: View {
+        var words: [WordModel]
+        var startAt: Int
+        var endAt: Int
+        var containerWidth: CGFloat
+        var isFastSentence: Bool
+        var isSlowSentence: Bool
+        var nowSentece: Int
+        var sentenceIndex: Int
+        var completion: (_ sentenceIndex: Int) -> Void
+        
+        var body: some View {
+            var offsetX = 0.0
+            var offsetY = 0.0
+            
+            ZStack(alignment: .topLeading) {
+                ForEach(words, id: \.id) { word in
+                    Text("\(word.word)")
+                        .alignmentGuide(.leading) { item in
+                            /// lineHeight
+                            if abs(offsetX - item.width) > containerWidth {
+                                offsetX = 0
+                                offsetY -= item.height + 8
+                            }
+                            let result = offsetX
+                            if endAt == word.index {
+                                offsetX = 0
+                            } else {
+                                offsetX -= item.width
+                            }
+                            return result
+                        }
+                        .alignmentGuide(.top) { _ in
+                            let result = offsetY
+                            if endAt == word.index {
+                                offsetY = 0
+                            }
+                            return result
+                        }
+                        .systemFont(
+                            word.isFillerWord || nowSentece == word.sentenceIndex
+                            ? .subTitle
+                            : .body
+                        )
+                        .foregroundStyle(
+                            word.isFillerWord
+                            ? Color.HPPrimary.base
+                            : nowSentece == word.sentenceIndex
+                            ? Color.HPTextStyle.darker
+                            : Color.HPTextStyle.base
+                        )
+                        .background(
+                            Rectangle()
+                                .frame(height: 8, alignment: .bottom)
+                                .offset(
+                                    y: nowSentece == word.sentenceIndex
+                                    ? 4
+                                    : word.isFillerWord
+                                    ? 6.5
+                                    : 4
+                                )
+                                .foregroundStyle(
+                                    isFastSentence || isSlowSentence
+                                    ? Color.HPComponent.highlight
+                                    : Color.clear
+                                )
+                        )
+                        .offset(
+                            y: nowSentece == word.sentenceIndex
+                            ? 0
+                            : word.isFillerWord
+                            ? -4
+                            : 0
+                        )
+                }
+            }
+            .frame(
+                minWidth: containerWidth,
+                maxWidth: containerWidth,
+                alignment: .topLeading
+            )
+            .onTapGesture {
+                completion(sentenceIndex)
+            }
+        }
     }
 }
 
 #Preview {
-    EveryFeedbackContent()
+    let modelContainer = SwiftDataMockManager.previewContainer
+    return VStack {
+        EveryFeedbackContent()
+            .modelContainer(modelContainer)
+            .environment(PracticeViewStore(
+                practice: PracticeModel(
+                    practiceName: "",
+                    index: 0,
+                    isVisited: false,
+                    creatAt: "",
+                    utterances: [],
+                    summary: PracticeSummaryModel()
+                ),
+                mediaManager: MediaManager()))
+    }
+    .frame(minWidth: 440, maxWidth: 440,  minHeight: 600)
+    .padding(24)
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
@@ -22,7 +22,7 @@ struct EveryFeedbackContent: View {
     
     var body: some View {
         VStack {
-            
+            Text("every")
         }
         .onAppear {
             // MARK: - Add MockData

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/EveryFeedbackContent.swift
@@ -13,7 +13,7 @@ import SwiftData
 struct EveryFeedbackContent: View {
     @Environment(PracticeViewStore.self)
     var viewStore
-    
+
 #if PREVIEW
     // MARK: - MockData
     @Query(sort: \PracticeModel.creatAt)
@@ -21,44 +21,8 @@ struct EveryFeedbackContent: View {
 #endif
     
     var body: some View {
-        ScrollView {
-            ScrollViewReader { scrollViewProxy in
-                VStack(alignment:. leading, spacing: .zero) {
-                    let sentences = viewStore.getSortedSentences()
-                    ForEach(sentences) { sentence in
-                        let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
-                        if let startAt = words.first?.index, let endAt = words.last?.index {
-                            ScriptCell(
-                                words: words,
-                                startAt: startAt,
-                                endAt: endAt,
-                                containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
-                                isFastSentence: viewStore.isFastSentence(sentenceIndex: sentence.index),
-                                isSlowSentence: viewStore.isSlowSentence(sentenceIndex: sentence.index),
-                                nowSentece: viewStore.nowSentence,
-                                sentenceIndex: sentence.index) { sentenceIndex in
-                                    print(sentenceIndex)
-                                    viewStore.nowSentence = sentenceIndex
-                                }
-                                .id(sentence.index)
-                                .padding(.bottom, .HPSpacing.xxxxsmall)
-                        }
-                    }
-                }
-                .frame(
-                    minWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
-                    maxWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
-                    maxHeight:.infinity,
-                    alignment: .topLeading
-                )
-                .padding(.bottom, .HPSpacing.xxxlarge + .HPSpacing.xxxsmall)
-                .padding(.horizontal, .HPSpacing.medium)
-                .onChange(of: viewStore.nowSentence) { _, newValue in
-                    withAnimation {
-                        scrollViewProxy.scrollTo(newValue, anchor: .center)
-                    }
-                }
-            }
+        VStack {
+            
         }
         .onAppear {
             // MARK: - Add MockData
@@ -72,110 +36,21 @@ struct EveryFeedbackContent: View {
     }
 }
 
-extension EveryFeedbackContent {
-    struct ScriptCell: View {
-        var words: [WordModel]
-        var startAt: Int
-        var endAt: Int
-        var containerWidth: CGFloat
-        var isFastSentence: Bool
-        var isSlowSentence: Bool
-        var nowSentece: Int
-        var sentenceIndex: Int
-        var completion: (_ sentenceIndex: Int) -> Void
-        
-        var body: some View {
-            var offsetX = 0.0
-            var offsetY = 0.0
-            
-            ZStack(alignment: .topLeading) {
-                ForEach(words, id: \.id) { word in
-                    Text("\(word.word)")
-                        .alignmentGuide(.leading) { item in
-                            /// lineHeight
-                            if abs(offsetX - item.width) > containerWidth {
-                                offsetX = 0
-                                offsetY -= item.height + 8
-                            }
-                            let result = offsetX
-                            if endAt == word.index {
-                                offsetX = 0
-                            } else {
-                                offsetX -= item.width
-                            }
-                            return result
-                        }
-                        .alignmentGuide(.top) { _ in
-                            let result = offsetY
-                            if endAt == word.index {
-                                offsetY = 0
-                            }
-                            return result
-                        }
-                        .systemFont(
-                            word.isFillerWord || nowSentece == word.sentenceIndex
-                            ? .subTitle
-                            : .body
-                        )
-                        .foregroundStyle(
-                            word.isFillerWord
-                            ? Color.HPPrimary.base
-                            : nowSentece == word.sentenceIndex
-                            ? Color.HPTextStyle.darker
-                            : Color.HPTextStyle.base
-                        )
-                        .background(
-                            Rectangle()
-                                .frame(height: 8, alignment: .bottom)
-                                .offset(
-                                    y: nowSentece == word.sentenceIndex
-                                    ? 4
-                                    : word.isFillerWord
-                                    ? 6.5
-                                    : 4
-                                )
-                                .foregroundStyle(
-                                    isFastSentence || isSlowSentence
-                                    ? Color.HPComponent.highlight
-                                    : Color.clear
-                                )
-                        )
-                        .offset(
-                            y: nowSentece == word.sentenceIndex
-                            ? 0
-                            : word.isFillerWord
-                            ? -4
-                            : 0
-                        )
-                }
-            }
-            .frame(
-                minWidth: containerWidth,
-                maxWidth: containerWidth,
-                alignment: .topLeading
-            )
-            .onTapGesture {
-                completion(sentenceIndex)
-            }
-        }
-    }
-}
-
 #Preview {
     let modelContainer = SwiftDataMockManager.previewContainer
     return VStack {
         EveryFeedbackContent()
-            .modelContainer(modelContainer)
-            .environment(PracticeViewStore(
-                practice: PracticeModel(
-                    practiceName: "",
-                    index: 0,
-                    isVisited: false,
-                    creatAt: "",
-                    utterances: [],
-                    summary: PracticeSummaryModel()
-                ),
-                mediaManager: MediaManager()))
+        .modelContainer(modelContainer)
+        .environment(PracticeViewStore(
+            practice: PracticeModel(
+                practiceName: "",
+                index: 0,
+                isVisited: false,
+                creatAt: "",
+                utterances: [],
+                summary: PracticeSummaryModel()
+            ),
+            mediaManager: MediaManager()))
     }
     .frame(minWidth: 440, maxWidth: 440,  minHeight: 600)
     .padding(24)

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FeedbackStyleScript.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FeedbackStyleScript.swift
@@ -1,0 +1,357 @@
+//
+//  FeedbackStyleScript.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/12/23.
+//
+
+import SwiftUI
+#if PREVIEW
+import SwiftData
+#endif
+
+struct FeedbackStyleScript: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+#if PREVIEW
+    // MARK: - MockData
+    @Query(sort: \PracticeModel.creatAt)
+    var practices: [PracticeModel]
+#endif
+    
+    var body: some View {
+        ScrollViewReader { scrollViewProxy in
+            scriptContainer
+                .onChange(of: viewStore.nowSentence) { _, newValue in
+                    withAnimation {
+                        scrollViewProxy.scrollTo(newValue, anchor: .center)
+                    }
+                }
+                .onChange(of: viewStore.currentFeedbackViewType) { _, _ in
+                    withAnimation {
+                        scrollViewProxy.scrollTo(viewStore.nowSentence, anchor: .center)
+                    }
+                }
+        }
+        .onAppear {
+            // MARK: - Add MockData
+#if PREVIEW
+            if let sample = practices.first {
+                viewStore.practice = sample
+            }
+#endif
+        }
+    }
+}
+
+extension FeedbackStyleScript {
+    private func intToMMSS(input: Int) -> String {
+        let minute = input / 1000 / 60
+        let second = input / 1000 % 60
+        
+        var displayMinute = minute.description
+        var displaySecond = second.description
+        
+        if minute < 10 {
+            displayMinute = "0\(displayMinute)"
+        }
+        if second < 10 {
+            displaySecond = "0\(displaySecond)"
+        }
+        
+        return "\(displayMinute):\(displaySecond)"
+    }
+}
+
+extension FeedbackStyleScript {
+    @ViewBuilder
+    private var scriptContainer: some View {
+        VStack(spacing: .zero) {
+            let sentences = viewStore.getSortedSentences()
+            ForEach(sentences) { sentence in
+                scriptCell(sentence: sentence)
+            }
+        }
+        .padding(.horizontal, .HPSpacing.small)
+        .padding(.bottom, .HPSpacing.xxxlarge + .HPSpacing.xxxsmall)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    func scriptCell(sentence: SentenceModel) -> some View {
+        let isSelected = viewStore.nowSentence == sentence.index
+        
+        return VStack {
+            switch viewStore.currentFeedbackViewType {
+            case .every:
+                HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
+                    let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+                    if let startAt = words.first?.index, let endAt = words.last?.index {
+                        EveryScriptCell(
+                            words: words,
+                            startAt: startAt,
+                            endAt: endAt,
+                            containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                            isFastSentence: viewStore.isFastSentence(sentenceIndex: sentence.index),
+                            isSlowSentence: viewStore.isSlowSentence(sentenceIndex: sentence.index),
+                            nowSentece: viewStore.nowSentence,
+                            sentenceIndex: sentence.index) { sentenceIndex in
+                                print(sentenceIndex)
+                                viewStore.nowSentence = sentenceIndex
+                            }
+                            .id(sentence.index)
+                            .padding(.bottom, .HPSpacing.xxxxsmall)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(.vertical, .HPSpacing.xxxsmall)
+                .padding(.horizontal, .HPSpacing.xxsmall)
+                .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+            case .fillerWord:
+                HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
+                    HPLabel(
+                        content: (intToMMSS(input: sentence.startAt), nil),
+                        type: .blockFill(.HPCornerRadius.small),
+                        size: .small,
+                        color: isSelected ? .HPPrimary.lightness : .clear,
+                        contentColor: isSelected ? .HPPrimary.dark : .HPPrimary.light,
+                        fontStyle: .systemDetail(.footnote, .semibold),
+                        padding: (.zero, .HPSpacing.xxxsmall)
+                    )
+                    .fixedSize()
+                    let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+                    if let startAt = words.first?.index, let endAt = words.last?.index {
+                        FillerWordScriptCell(
+                            words: words,
+                            startAt: startAt,
+                            endAt: endAt,
+                            containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                            nowSentece: viewStore.nowSentence,
+                            sentenceIndex: sentence.index) { sentenceIndex in
+                                viewStore.nowSentence = sentenceIndex
+                            }
+                            .id(sentence.index)
+                            .padding(.bottom, .HPSpacing.xxxxsmall)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(.vertical, .HPSpacing.xxxsmall)
+                .padding(.horizontal, .HPSpacing.xxsmall)
+                .background(isSelected ? Color.HPComponent.Section.point : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+            case .speed:
+                HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
+                    HPLabel(
+                        content: (intToMMSS(input: sentence.startAt), nil),
+                        type: .blockFill(.HPCornerRadius.small),
+                        size: .small,
+                        color: isSelected ? .HPPrimary.lightness : .clear,
+                        contentColor: isSelected ? .HPPrimary.dark : .HPPrimary.light,
+                        fontStyle: .systemDetail(.footnote, .semibold),
+                        padding: (.zero, .HPSpacing.xxxsmall)
+                    )
+                    .fixedSize()
+                    let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+                    if let startAt = words.first?.index, let endAt = words.last?.index {
+                        FillerWordScriptCell(
+                            words: words,
+                            startAt: startAt,
+                            endAt: endAt,
+                            containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                            nowSentece: viewStore.nowSentence,
+                            sentenceIndex: sentence.index) { sentenceIndex in
+                                viewStore.nowSentence = sentenceIndex
+                            }
+                            .id(sentence.index)
+                            .padding(.bottom, .HPSpacing.xxxxsmall)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(.vertical, .HPSpacing.xxxsmall)
+                .padding(.horizontal, .HPSpacing.xxsmall)
+                .background(isSelected ? Color.HPComponent.Section.point : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+            }
+        }
+    }
+}
+
+extension FeedbackStyleScript {
+    struct FillerWordScriptCell: View {
+        var words: [WordModel]
+        var startAt: Int
+        var endAt: Int
+        var containerWidth: CGFloat
+        var nowSentece: Int
+        var sentenceIndex: Int
+        var completion: (_ sentenceIndex: Int) -> Void
+        
+        var body: some View {
+            var offsetX = 0.0
+            var offsetY = 0.0
+            
+            ZStack(alignment: .topLeading) {
+                ForEach(words, id: \.id) { word in
+                    Text("\(word.word)")
+                        .alignmentGuide(.leading) { item in
+                            /// lineHeight
+                            if abs(offsetX - item.width) > containerWidth {
+                                offsetX = 0
+                                offsetY -= item.height + 8
+                            }
+                            let result = offsetX
+                            if endAt == word.index {
+                                offsetX = 0
+                            } else {
+                                offsetX -= item.width
+                            }
+                            return result
+                        }
+                        .alignmentGuide(.top) { _ in
+                            let result = offsetY
+                            if endAt == word.index {
+                                offsetY = 0
+                            }
+                            return result
+                        }
+                        .systemFont(
+                            word.isFillerWord || nowSentece == word.sentenceIndex
+                            ? .subTitle
+                            : .body
+                        )
+                        .foregroundStyle(
+                            word.isFillerWord
+                            ? Color.HPPrimary.base
+                            : nowSentece == word.sentenceIndex
+                            ? Color.HPTextStyle.darker
+                            : Color.HPTextStyle.base
+                        )
+                        .offset(
+                            y: nowSentece == word.sentenceIndex
+                            ? 0
+                            : word.isFillerWord
+                            ? -4
+                            : 0
+                        )
+                }
+            }
+            .frame(
+                minWidth: containerWidth,
+                maxWidth: containerWidth,
+                alignment: .topLeading
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                completion(sentenceIndex)
+            }
+        }
+    }
+    
+    struct EveryScriptCell: View {
+        var words: [WordModel]
+        var startAt: Int
+        var endAt: Int
+        var containerWidth: CGFloat
+        var isFastSentence: Bool
+        var isSlowSentence: Bool
+        var nowSentece: Int
+        var sentenceIndex: Int
+        var completion: (_ sentenceIndex: Int) -> Void
+        
+        var body: some View {
+            var offsetX = 0.0
+            var offsetY = 0.0
+            
+            ZStack(alignment: .topLeading) {
+                ForEach(words, id: \.id) { word in
+                    Text("\(word.word)")
+                        .alignmentGuide(.leading) { item in
+                            /// lineHeight
+                            if abs(offsetX - item.width) > containerWidth {
+                                offsetX = 0
+                                offsetY -= item.height + 8
+                            }
+                            let result = offsetX
+                            if endAt == word.index {
+                                offsetX = 0
+                            } else {
+                                offsetX -= item.width
+                            }
+                            return result
+                        }
+                        .alignmentGuide(.top) { _ in
+                            let result = offsetY
+                            if endAt == word.index {
+                                offsetY = 0
+                            }
+                            return result
+                        }
+                        .systemFont(
+                            word.isFillerWord || nowSentece == word.sentenceIndex
+                            ? .subTitle
+                            : .body
+                        )
+                        .foregroundStyle(
+                            word.isFillerWord
+                            ? Color.HPPrimary.base
+                            : nowSentece == word.sentenceIndex
+                            ? Color.HPTextStyle.darker
+                            : Color.HPTextStyle.base
+                        )
+                        .background(
+                            Rectangle()
+                                .frame(height: 8, alignment: .bottom)
+                                .offset(
+                                    y: nowSentece == word.sentenceIndex
+                                    ? 4
+                                    : word.isFillerWord
+                                    ? 6.5
+                                    : 4
+                                )
+                                .foregroundStyle(
+                                    isFastSentence || isSlowSentence
+                                    ? Color.HPComponent.highlight
+                                    : Color.clear
+                                )
+                        )
+                        .offset(
+                            y: nowSentece == word.sentenceIndex
+                            ? 0
+                            : word.isFillerWord
+                            ? -4
+                            : 0
+                        )
+                }
+            }
+            .frame(
+                minWidth: containerWidth,
+                maxWidth: containerWidth,
+                alignment: .topLeading
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                completion(sentenceIndex)
+            }
+        }
+    }
+}
+
+#Preview {
+    let modelContainer = SwiftDataMockManager.previewContainer
+    return VStack {
+        FeedbackStyleScript()
+            .modelContainer(modelContainer)
+            .environment(PracticeViewStore(
+                practice: PracticeModel(
+                    practiceName: "",
+                    index: 0,
+                    isVisited: false,
+                    creatAt: "",
+                    utterances: [],
+                    summary: PracticeSummaryModel()
+                ),
+                mediaManager: MediaManager()))
+    }
+    .frame(minWidth: 440, maxWidth: 440,  minHeight: 600)
+    .padding(24)
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FeedbackStyleScript.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FeedbackStyleScript.swift
@@ -40,6 +40,7 @@ struct FeedbackStyleScript: View {
             if let sample = practices.first {
                 viewStore.practice = sample
             }
+            viewStore.currentFeedbackViewType = .speed
 #endif
         }
     }
@@ -84,99 +85,192 @@ extension FeedbackStyleScript {
         return VStack {
             switch viewStore.currentFeedbackViewType {
             case .every:
-                HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
-                    let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
-                    if let startAt = words.first?.index, let endAt = words.last?.index {
-                        EveryScriptCell(
-                            words: words,
-                            startAt: startAt,
-                            endAt: endAt,
-                            containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
-                            isFastSentence: viewStore.isFastSentence(sentenceIndex: sentence.index),
-                            isSlowSentence: viewStore.isSlowSentence(sentenceIndex: sentence.index),
-                            nowSentece: viewStore.nowSentence,
-                            sentenceIndex: sentence.index) { sentenceIndex in
-                                print(sentenceIndex)
-                                viewStore.nowSentence = sentenceIndex
-                            }
-                            .id(sentence.index)
-                            .padding(.bottom, .HPSpacing.xxxxsmall)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .padding(.vertical, .HPSpacing.xxxsmall)
-                .padding(.horizontal, .HPSpacing.xxsmall)
-                .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+                everyScriptCell(sentence: sentence, isSelected: isSelected)
             case .fillerWord:
-                HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
-                    HPLabel(
-                        content: (intToMMSS(input: sentence.startAt), nil),
-                        type: .blockFill(.HPCornerRadius.small),
-                        size: .small,
-                        color: isSelected ? .HPPrimary.lightness : .clear,
-                        contentColor: isSelected ? .HPPrimary.dark : .HPPrimary.light,
-                        fontStyle: .systemDetail(.footnote, .semibold),
-                        padding: (.zero, .HPSpacing.xxxsmall)
-                    )
-                    .fixedSize()
-                    let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
-                    if let startAt = words.first?.index, let endAt = words.last?.index {
-                        FillerWordScriptCell(
-                            words: words,
-                            startAt: startAt,
-                            endAt: endAt,
-                            containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
-                            nowSentece: viewStore.nowSentence,
-                            sentenceIndex: sentence.index) { sentenceIndex in
-                                viewStore.nowSentence = sentenceIndex
-                            }
-                            .id(sentence.index)
-                            .padding(.bottom, .HPSpacing.xxxxsmall)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .padding(.vertical, .HPSpacing.xxxsmall)
-                .padding(.horizontal, .HPSpacing.xxsmall)
-                .background(isSelected ? Color.HPComponent.Section.point : .clear)
-                .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+                fillerWordScriptCell(sentence: sentence, isSelected: isSelected)
             case .speed:
-                HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
-                    HPLabel(
-                        content: (intToMMSS(input: sentence.startAt), nil),
-                        type: .blockFill(.HPCornerRadius.small),
-                        size: .small,
-                        color: isSelected ? .HPPrimary.lightness : .clear,
-                        contentColor: isSelected ? .HPPrimary.dark : .HPPrimary.light,
-                        fontStyle: .systemDetail(.footnote, .semibold),
-                        padding: (.zero, .HPSpacing.xxxsmall)
-                    )
-                    .fixedSize()
-                    let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
-                    if let startAt = words.first?.index, let endAt = words.last?.index {
-                        FillerWordScriptCell(
-                            words: words,
-                            startAt: startAt,
-                            endAt: endAt,
-                            containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
-                            nowSentece: viewStore.nowSentence,
-                            sentenceIndex: sentence.index) { sentenceIndex in
-                                viewStore.nowSentence = sentenceIndex
-                            }
-                            .id(sentence.index)
-                            .padding(.bottom, .HPSpacing.xxxxsmall)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .padding(.vertical, .HPSpacing.xxxsmall)
-                .padding(.horizontal, .HPSpacing.xxsmall)
-                .background(isSelected ? Color.HPComponent.Section.point : .clear)
-                .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+                speedScriptCell(sentence: sentence, isSelected: isSelected)
             }
         }
+    }
+    
+    @ViewBuilder
+    func everyScriptCell(sentence: SentenceModel, isSelected: Bool) -> some View {
+        HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
+            let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+            if let startAt = words.first?.index, let endAt = words.last?.index {
+                EveryScriptCell(
+                    words: words,
+                    startAt: startAt,
+                    endAt: endAt,
+                    containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                    isFastSentence: viewStore.isFastSentence(sentenceIndex: sentence.index),
+                    isSlowSentence: viewStore.isSlowSentence(sentenceIndex: sentence.index),
+                    nowSentece: viewStore.nowSentence,
+                    sentenceIndex: sentence.index) { sentenceIndex in
+                        print(sentenceIndex)
+                        viewStore.nowSentence = sentenceIndex
+                    }
+                    .id(sentence.index)
+                    .padding(.bottom, .HPSpacing.xxxxsmall)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(.vertical, .HPSpacing.xxxsmall)
+        .padding(.horizontal, .HPSpacing.xxsmall)
+        .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+    }
+    
+    @ViewBuilder
+    func fillerWordScriptCell(sentence: SentenceModel, isSelected: Bool) -> some View {
+        HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
+            HPLabel(
+                content: (intToMMSS(input: sentence.startAt), nil),
+                type: .blockFill(.HPCornerRadius.small),
+                size: .small,
+                color: isSelected ? .HPPrimary.lightness : .clear,
+                contentColor: isSelected ? .HPPrimary.dark : .HPPrimary.light,
+                fontStyle: .systemDetail(.footnote, .semibold),
+                padding: (.zero, .HPSpacing.xxxsmall)
+            )
+            .fixedSize()
+            let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+            if let startAt = words.first?.index, let endAt = words.last?.index {
+                FillerWordScriptCell(
+                    words: words,
+                    startAt: startAt,
+                    endAt: endAt,
+                    containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                    nowSentece: viewStore.nowSentence,
+                    sentenceIndex: sentence.index) { sentenceIndex in
+                        viewStore.nowSentence = sentenceIndex
+                    }
+                    .id(sentence.index)
+                    .padding(.bottom, .HPSpacing.xxxxsmall)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(.vertical, .HPSpacing.xxxsmall)
+        .padding(.horizontal, .HPSpacing.xxsmall)
+        .background(isSelected ? Color.HPComponent.Section.point : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+    }
+    
+    @ViewBuilder
+    func speedScriptCell(sentence: SentenceModel, isSelected: Bool) -> some View {
+        let isFast = viewStore.isFastSentence(sentenceIndex: sentence.index)
+        let isSlow = viewStore.isSlowSentence(sentenceIndex: sentence.index)
+                                              
+        HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
+            VStack {
+                HPLabel(
+                    content: (intToMMSS(input: sentence.startAt), nil),
+                    type: .blockFill(.HPCornerRadius.small),
+                    size: .small,
+                    color: isSelected ? .HPComponent.highlight : .clear,
+                    contentColor: isSelected ? .HPOrange.base : .HPOrange.light,
+                    fontStyle: .systemDetail(.footnote, .semibold),
+                    padding: (.zero, .HPSpacing.xxxsmall)
+                )
+                .fixedSize()
+                if isFast {
+                    Image(systemName: "hare.fill")
+                        .foregroundStyle(Color.HPRed.base)
+                }
+                if isSlow {
+                    Image(systemName: "tortoise.fill")
+                        .foregroundStyle(Color.HPRed.base)
+                }
+            }
+            let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+            if let startAt = words.first?.index, let endAt = words.last?.index {
+                SpeedScriptCell(
+                    words: words,
+                    startAt: startAt,
+                    endAt: endAt,
+                    containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                    isFastSentence: isFast,
+                    isSlowSentence: isSlow,
+                    nowSentece: viewStore.nowSentence,
+                    sentenceIndex: sentence.index) { sentenceIndex in
+                        viewStore.nowSentence = sentenceIndex
+                    }
+                    .id(sentence.index)
+                    .padding(.bottom, .HPSpacing.xxxxsmall)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(.vertical, .HPSpacing.xxxsmall)
+        .padding(.horizontal, .HPSpacing.xxsmall)
+        .background(isSelected ? Color.HPComponent.SpeedFeedback.background : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
     }
 }
 
 extension FeedbackStyleScript {
+    struct SpeedScriptCell: View {
+        var words: [WordModel]
+        var startAt: Int
+        var endAt: Int
+        var containerWidth: CGFloat
+        var isFastSentence: Bool
+        var isSlowSentence: Bool
+        var nowSentece: Int
+        var sentenceIndex: Int
+        var completion: (_ sentenceIndex: Int) -> Void
+        
+        var body: some View {
+            var offsetX = 0.0
+            var offsetY = 0.0
+            
+            ZStack(alignment: .topLeading) {
+                ForEach(words, id: \.id) { word in
+                    Text("\(word.word)")
+                        .alignmentGuide(.leading) { item in
+                            /// lineHeight
+                            if abs(offsetX - item.width) > containerWidth {
+                                offsetX = 0
+                                offsetY -= item.height + 8
+                            }
+                            let result = offsetX
+                            if endAt == word.index {
+                                offsetX = 0
+                            } else {
+                                offsetX -= item.width
+                            }
+                            return result
+                        }
+                        .alignmentGuide(.top) { _ in
+                            let result = offsetY
+                            if endAt == word.index {
+                                offsetY = 0
+                            }
+                            return result
+                        }
+                        .systemFont(
+                            nowSentece == word.sentenceIndex
+                            ? .subTitle
+                            : .body
+                        )
+                        .foregroundStyle(
+                            nowSentece == word.sentenceIndex
+                            ? Color.HPTextStyle.darker
+                            : Color.HPTextStyle.base
+                        )
+                }
+            }
+            .frame(
+                minWidth: containerWidth,
+                maxWidth: containerWidth,
+                alignment: .topLeading
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                completion(sentenceIndex)
+            }
+        }
+    }
+    
     struct FillerWordScriptCell: View {
         var words: [WordModel]
         var startAt: Int

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
@@ -21,18 +21,15 @@ struct FillerWordFeedbackContent: View {
 #endif
     
     var body: some View {
-        ScrollView {
-            VStack(spacing: .HPSpacing.xsmall) {
-                chartContainer
-                scriptContainer
-            }
-            .padding(.bottom, .HPSpacing.small)
-            .frame(
-                maxWidth: .infinity,
-                maxHeight: .infinity,
-                alignment: .topLeading
-            )
+        VStack(spacing: .HPSpacing.xsmall) {
+            chartContainer
         }
+        .padding(.bottom, .HPSpacing.small)
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity,
+            alignment: .topLeading
+        )
         .onAppear {
             // MARK: - Add MockData
 #if PREVIEW
@@ -45,25 +42,6 @@ struct FillerWordFeedbackContent: View {
 }
 
 extension FillerWordFeedbackContent {
-    private func intToMMSS(input: Int) -> String {
-        let minute = input / 1000 / 60
-        let second = input / 1000 % 60
-        
-        var displayMinute = minute.description
-        var displaySecond = second.description
-        
-        if minute < 10 {
-            displayMinute = "0\(displayMinute)"
-        }
-        if second < 10 {
-            displaySecond = "0\(displaySecond)"
-        }
-        
-        return "\(displayMinute):\(displaySecond)"
-    }
-}
-
-extension FillerWordFeedbackContent {
     @ViewBuilder
     private var chartContainer: some View {
         HPArcodianView(label: "사용된 습관어 종류 및 횟수") {
@@ -72,144 +50,23 @@ extension FillerWordFeedbackContent {
         .fixedSize(horizontal: false, vertical: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
         .padding(.horizontal, .HPSpacing.small)
     }
-    
-    @ViewBuilder
-    private var scriptContainer: some View {
-        VStack(spacing: .zero) {
-            let sentences = viewStore.getSortedSentences()
-            ForEach(sentences) { sentence in
-                scriptCell(sentence: sentence)
-            }
-        }
-        .padding(.horizontal, .HPSpacing.small)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-    
-    func scriptCell(sentence: SentenceModel) -> some View {
-        let isSelected = viewStore.nowSentence == sentence.index
-        
-        return HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
-            HPLabel(
-                content: (intToMMSS(input: sentence.startAt), nil),
-                type: .blockFill(.HPCornerRadius.small),
-                size: .small,
-                color: isSelected ? .HPPrimary.lightness : .clear,
-                contentColor: isSelected ? .HPPrimary.dark : .HPPrimary.light,
-                fontStyle: .systemDetail(.footnote, .semibold),
-                padding: (.zero, .HPSpacing.xxxsmall)
-            )
-            .fixedSize()
-            let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
-            if let startAt = words.first?.index, let endAt = words.last?.index {
-                ScriptCell(
-                    words: words,
-                    startAt: startAt,
-                    endAt: endAt,
-                    containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
-                    nowSentece: viewStore.nowSentence,
-                    sentenceIndex: sentence.index) { sentenceIndex in
-                        viewStore.nowSentence = sentenceIndex
-                    }
-                    .id(sentence.index)
-                    .padding(.bottom, .HPSpacing.xxxxsmall)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .padding(.vertical, .HPSpacing.xxxsmall)
-        .padding(.horizontal, .HPSpacing.xxsmall)
-        .background(isSelected ? Color.HPComponent.Section.point : .clear)
-        .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
-    }
-}
-
-extension FillerWordFeedbackContent {
-    
-    
-    struct ScriptCell: View {
-        var words: [WordModel]
-        var startAt: Int
-        var endAt: Int
-        var containerWidth: CGFloat
-        var nowSentece: Int
-        var sentenceIndex: Int
-        var completion: (_ sentenceIndex: Int) -> Void
-        
-        var body: some View {
-            var offsetX = 0.0
-            var offsetY = 0.0
-            
-            ZStack(alignment: .topLeading) {
-                ForEach(words, id: \.id) { word in
-                    Text("\(word.word)")
-                        .alignmentGuide(.leading) { item in
-                            /// lineHeight
-                            if abs(offsetX - item.width) > containerWidth {
-                                offsetX = 0
-                                offsetY -= item.height + 8
-                            }
-                            let result = offsetX
-                            if endAt == word.index {
-                                offsetX = 0
-                            } else {
-                                offsetX -= item.width
-                            }
-                            return result
-                        }
-                        .alignmentGuide(.top) { _ in
-                            let result = offsetY
-                            if endAt == word.index {
-                                offsetY = 0
-                            }
-                            return result
-                        }
-                        .systemFont(
-                            word.isFillerWord || nowSentece == word.sentenceIndex
-                            ? .subTitle
-                            : .body
-                        )
-                        .foregroundStyle(
-                            word.isFillerWord
-                            ? Color.HPPrimary.base
-                            : nowSentece == word.sentenceIndex
-                            ? Color.HPTextStyle.darker
-                            : Color.HPTextStyle.base
-                        )
-                        .offset(
-                            y: nowSentece == word.sentenceIndex
-                            ? 0
-                            : word.isFillerWord
-                            ? -4
-                            : 0
-                        )
-                }
-            }
-            .frame(
-                minWidth: containerWidth,
-                maxWidth: containerWidth,
-                alignment: .topLeading
-            )
-            .onTapGesture {
-                completion(sentenceIndex)
-            }
-        }
-    }
 }
 
 #Preview {
     let modelContainer = SwiftDataMockManager.previewContainer
     return VStack {
         FillerWordFeedbackContent()
-            .modelContainer(modelContainer)
-            .environment(PracticeViewStore(
-                practice: PracticeModel(
-                    practiceName: "",
-                    index: 0,
-                    isVisited: false,
-                    creatAt: "",
-                    utterances: [],
-                    summary: PracticeSummaryModel()
-                ),
-                mediaManager: MediaManager()))
+        .modelContainer(modelContainer)
+        .environment(PracticeViewStore(
+            practice: PracticeModel(
+                practiceName: "",
+                index: 0,
+                isVisited: false,
+                creatAt: "",
+                utterances: [],
+                summary: PracticeSummaryModel()
+            ),
+            mediaManager: MediaManager()))
     }
     .frame(minWidth: 440, maxWidth: 440,  minHeight: 600)
     .padding(24)

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
@@ -1,0 +1,18 @@
+//
+//  FillerWordFeedbackContent.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/9/23.
+//
+
+import SwiftUI
+
+struct FillerWordFeedbackContent: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    FillerWordFeedbackContent()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
@@ -26,6 +26,7 @@ struct FillerWordFeedbackContent: View {
                 chartContainer
                 scriptContainer
             }
+            .padding(.bottom, .HPSpacing.small)
             .frame(
                 maxWidth: .infinity,
                 maxHeight: .infinity,
@@ -44,6 +45,25 @@ struct FillerWordFeedbackContent: View {
 }
 
 extension FillerWordFeedbackContent {
+    private func intToMMSS(input: Int) -> String {
+        let minute = input / 1000 / 60
+        let second = input / 1000 % 60
+        
+        var displayMinute = minute.description
+        var displaySecond = second.description
+        
+        if minute < 10 {
+            displayMinute = "0\(displayMinute)"
+        }
+        if second < 10 {
+            displaySecond = "0\(displaySecond)"
+        }
+        
+        return "\(displayMinute):\(displaySecond)"
+    }
+}
+
+extension FillerWordFeedbackContent {
     @ViewBuilder
     private var chartContainer: some View {
         HPArcodianView(label: "사용된 습관어 종류 및 횟수") {
@@ -55,8 +75,122 @@ extension FillerWordFeedbackContent {
     
     @ViewBuilder
     private var scriptContainer: some View {
-        VStack {
-            Text("차트")
+        VStack(spacing: .zero) {
+            let sentences = viewStore.getSortedSentences()
+            ForEach(sentences) { sentence in
+                scriptCell(sentence: sentence)
+            }
+        }
+        .padding(.horizontal, .HPSpacing.small)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    func scriptCell(sentence: SentenceModel) -> some View {
+        let isSelected = viewStore.nowSentence == sentence.index
+        
+        return HStack(alignment: .top, spacing: .HPSpacing.xxsmall) {
+            HPLabel(
+                content: (intToMMSS(input: sentence.startAt), nil),
+                type: .blockFill(.HPCornerRadius.small),
+                size: .small,
+                color: isSelected ? .HPPrimary.lightness : .clear,
+                contentColor: isSelected ? .HPPrimary.dark : .HPPrimary.light,
+                fontStyle: .systemDetail(.footnote, .semibold),
+                padding: (.zero, .HPSpacing.xxxsmall)
+            )
+            .fixedSize()
+            let words = viewStore.getContainsWords(sentenceIndex: sentence.index)
+            if let startAt = words.first?.index, let endAt = words.last?.index {
+                ScriptCell(
+                    words: words,
+                    startAt: startAt,
+                    endAt: endAt,
+                    containerWidth: viewStore.SCRIPT_CONTAINER_WIDTH,
+                    nowSentece: viewStore.nowSentence,
+                    sentenceIndex: sentence.index) { sentenceIndex in
+                        viewStore.nowSentence = sentenceIndex
+                    }
+                    .id(sentence.index)
+                    .padding(.bottom, .HPSpacing.xxxxsmall)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(.vertical, .HPSpacing.xxxsmall)
+        .padding(.horizontal, .HPSpacing.xxsmall)
+        .background(isSelected ? Color.HPComponent.Section.point : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: .HPCornerRadius.medium))
+    }
+}
+
+extension FillerWordFeedbackContent {
+    
+    
+    struct ScriptCell: View {
+        var words: [WordModel]
+        var startAt: Int
+        var endAt: Int
+        var containerWidth: CGFloat
+        var nowSentece: Int
+        var sentenceIndex: Int
+        var completion: (_ sentenceIndex: Int) -> Void
+        
+        var body: some View {
+            var offsetX = 0.0
+            var offsetY = 0.0
+            
+            ZStack(alignment: .topLeading) {
+                ForEach(words, id: \.id) { word in
+                    Text("\(word.word)")
+                        .alignmentGuide(.leading) { item in
+                            /// lineHeight
+                            if abs(offsetX - item.width) > containerWidth {
+                                offsetX = 0
+                                offsetY -= item.height + 8
+                            }
+                            let result = offsetX
+                            if endAt == word.index {
+                                offsetX = 0
+                            } else {
+                                offsetX -= item.width
+                            }
+                            return result
+                        }
+                        .alignmentGuide(.top) { _ in
+                            let result = offsetY
+                            if endAt == word.index {
+                                offsetY = 0
+                            }
+                            return result
+                        }
+                        .systemFont(
+                            word.isFillerWord || nowSentece == word.sentenceIndex
+                            ? .subTitle
+                            : .body
+                        )
+                        .foregroundStyle(
+                            word.isFillerWord
+                            ? Color.HPPrimary.base
+                            : nowSentece == word.sentenceIndex
+                            ? Color.HPTextStyle.darker
+                            : Color.HPTextStyle.base
+                        )
+                        .offset(
+                            y: nowSentece == word.sentenceIndex
+                            ? 0
+                            : word.isFillerWord
+                            ? -4
+                            : 0
+                        )
+                }
+            }
+            .frame(
+                minWidth: containerWidth,
+                maxWidth: containerWidth,
+                alignment: .topLeading
+            )
+            .onTapGesture {
+                completion(sentenceIndex)
+            }
         }
     }
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/FillerWordFeedbackContent.swift
@@ -6,13 +6,77 @@
 //
 
 import SwiftUI
+#if PREVIEW
+import SwiftData
+#endif
 
 struct FillerWordFeedbackContent: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+#if PREVIEW
+    // MARK: - MockData
+    @Query(sort: \PracticeModel.creatAt)
+    var practices: [PracticeModel]
+#endif
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ScrollView {
+            VStack(spacing: .HPSpacing.xsmall) {
+                chartContainer
+                scriptContainer
+            }
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity,
+                alignment: .topLeading
+            )
+        }
+        .onAppear {
+            // MARK: - Add MockData
+#if PREVIEW
+            if let sample = practices.first {
+                viewStore.practice = sample
+            }
+#endif
+        }
+    }
+}
+
+extension FillerWordFeedbackContent {
+    @ViewBuilder
+    private var chartContainer: some View {
+        HPArcodianView(label: "사용된 습관어 종류 및 횟수") {
+            Text("Hello")
+        }
+        .fixedSize(horizontal: false, vertical: /*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
+        .padding(.horizontal, .HPSpacing.small)
+    }
+    
+    @ViewBuilder
+    private var scriptContainer: some View {
+        VStack {
+            Text("차트")
+        }
     }
 }
 
 #Preview {
-    FillerWordFeedbackContent()
+    let modelContainer = SwiftDataMockManager.previewContainer
+    return VStack {
+        FillerWordFeedbackContent()
+            .modelContainer(modelContainer)
+            .environment(PracticeViewStore(
+                practice: PracticeModel(
+                    practiceName: "",
+                    index: 0,
+                    isVisited: false,
+                    creatAt: "",
+                    utterances: [],
+                    summary: PracticeSummaryModel()
+                ),
+                mediaManager: MediaManager()))
+    }
+    .frame(minWidth: 440, maxWidth: 440,  minHeight: 600)
+    .padding(24)
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/SpeedFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/SpeedFeedbackContent.swift
@@ -1,0 +1,18 @@
+//
+//  SpeedFeedbackContent.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/9/23.
+//
+
+import SwiftUI
+
+struct SpeedFeedbackContent: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    SpeedFeedbackContent()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/SpeedFeedbackContent.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/FeedbackContent/SpeedFeedbackContent.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SpeedFeedbackContent: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("Hello, Speed Feedback!")
     }
 }
 

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
@@ -26,14 +26,15 @@ struct PracticeDetailContainer: View {
         VStack(alignment: .leading, spacing: .zero) {
             header
             viewStore.currentFeedbackViewType.feedbackContent
+                .padding(.bottom, .HPSpacing.medium)
         }
+        .border(.HPComponent.stroke, width: 1, edges: [.leading])
         .frame(
             minWidth: PRACTICE_DETAIL_VIEW_WIDTH,
             maxWidth: PRACTICE_DETAIL_VIEW_WIDTH,
             maxHeight: .infinity,
             alignment: .topLeading
         )
-//        .background(Color.green)
         .onAppear {
             // MARK: - Add MockData
 #if PREVIEW

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
@@ -1,0 +1,55 @@
+//
+//  PracticeDetailContainer.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/8/23.
+//
+
+import SwiftUI
+
+struct PracticeDetailContainer: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+    private let PRACTICE_DETAIL_VIEW_WIDTH = 440.0
+    
+    var body: some View {
+        VStack {
+            HStack {
+                HStack {
+                    Text("전체보기")
+                        .onTapGesture {
+                            viewStore.currentFeedbackViewType = .every
+                        }
+                    Text("습관어")
+                        .onTapGesture {
+                            viewStore.currentFeedbackViewType = .fillerWord
+                        }
+                    Text("말 빠르기")
+                        .onTapGesture {
+                            viewStore.currentFeedbackViewType = .speed
+                        }
+                }
+                Text("리포트 보기")
+            }
+            /// 차트 컨테이너
+            VStack {
+                
+            }
+            /// 스크립트 컨테이너
+            VStack {
+                
+            }
+        }
+        .frame(
+            minWidth: PRACTICE_DETAIL_VIEW_WIDTH,
+            maxWidth: PRACTICE_DETAIL_VIEW_WIDTH,
+            maxHeight: .infinity
+        )
+        .background(Color.green)
+    }
+}
+
+#Preview {
+    PracticeDetailContainer()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+#if PREVIEW
+import SwiftData
+#endif
 
 struct PracticeDetailContainer: View {
     @Environment(PracticeViewStore.self)
@@ -13,43 +16,107 @@ struct PracticeDetailContainer: View {
     
     private let PRACTICE_DETAIL_VIEW_WIDTH = 440.0
     
+#if PREVIEW
+    // MARK: - MockData
+    @Query(sort: \PracticeModel.creatAt)
+    var practices: [PracticeModel]
+#endif
+    
     var body: some View {
-        VStack {
-            HStack {
-                HStack {
-                    Text("전체보기")
-                        .onTapGesture {
-                            viewStore.currentFeedbackViewType = .every
-                        }
-                    Text("습관어")
-                        .onTapGesture {
-                            viewStore.currentFeedbackViewType = .fillerWord
-                        }
-                    Text("말 빠르기")
-                        .onTapGesture {
-                            viewStore.currentFeedbackViewType = .speed
-                        }
-                }
-                Text("리포트 보기")
-            }
-            /// 차트 컨테이너
-            VStack {
-                
-            }
-            /// 스크립트 컨테이너
-            VStack {
-                
-            }
+        VStack(alignment: .leading, spacing: .zero) {
+            header
+            viewStore.currentFeedbackViewType.feedbackContent
         }
         .frame(
             minWidth: PRACTICE_DETAIL_VIEW_WIDTH,
             maxWidth: PRACTICE_DETAIL_VIEW_WIDTH,
-            maxHeight: .infinity
+            maxHeight: .infinity,
+            alignment: .topLeading
         )
-        .background(Color.green)
+//        .background(Color.green)
+        .onAppear {
+            // MARK: - Add MockData
+#if PREVIEW
+            if let sample = practices.first {
+                viewStore.practice = sample
+            }
+#endif
+        }
+    }
+}
+
+extension PracticeDetailContainer {
+    @ViewBuilder
+    var header: some View {
+        HStack {
+            segmentedControl
+            Spacer()
+            HPButton(type: .text, color: .HPTextStyle.light) {
+                print("리포트 보기")
+            } label: { type, size, color, expandable in
+                HPLabel(
+                    content: ("리포트 보기", nil),
+                    type: type,
+                    size: size,
+                    color: color,
+                    expandable: expandable
+                )
+            }
+            .fixedSize()
+        }
+        .padding(.top, .HPSpacing.xsmallBetweenSmall)
+        .padding(.bottom, .HPSpacing.small)
+        .padding(.leading, .HPSpacing.small)
+        .padding(.trailing, .HPSpacing.medium)
+    }
+    
+    @ViewBuilder
+    var segmentedControl: some View {
+        HStack {
+            ForEach(FeedbackViewType.allCases, id: \.rawValue) { option in
+                let isSelected = viewStore.currentFeedbackViewType == option
+                HPButton(
+                    type: .roundFill,
+                    size: .small,
+                    color: isSelected ? .HPSecondary.base : .HPGray.system200) {
+                    print("select \(option.rawValue)")
+                        withAnimation {
+                            viewStore.currentFeedbackViewType = option
+                        }
+                } label: { type, size, color, expandable in
+                    HPLabel(
+                        content: ("\(option.rawValue)", nil),
+                        type: type,
+                        size: size,
+                        color: color,
+                        contentColor: isSelected ? .HPGray.systemWhite : .HPTextStyle.base,
+                        expandable: expandable,
+                        padding: (.HPSpacing.xxxxsmall, .HPSpacing.xxsmall)
+                    )
+                }
+                .fixedSize()
+            }
+        }
     }
 }
 
 #Preview {
-    PracticeDetailContainer()
+    let modelContainer = SwiftDataMockManager.previewContainer
+    
+    return VStack {
+        PracticeDetailContainer()
+            .modelContainer(modelContainer)
+            .environment(PracticeViewStore(
+                practice: PracticeModel(
+                    practiceName: "",
+                    index: 0,
+                    isVisited: false,
+                    creatAt: "",
+                    utterances: [],
+                    summary: PracticeSummaryModel()
+                ),
+                mediaManager: MediaManager()))
+    }
+    .frame(minHeight: 600)
+    
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/PracticeDetailContainer/PracticeDetailContainer.swift
@@ -25,8 +25,12 @@ struct PracticeDetailContainer: View {
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
             header
-            viewStore.currentFeedbackViewType.feedbackContent
-                .padding(.bottom, .HPSpacing.medium)
+            ScrollView {
+                viewStore.currentFeedbackViewType.feedbackContent
+                FeedbackStyleScript()
+            }
+            .animation(nil, value: UUID())
+            .padding(.bottom, .HPSpacing.medium)
         }
         .border(.HPComponent.stroke, width: 1, edges: [.leading])
         .frame(

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/SplitViewContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/SplitViewContainer.swift
@@ -1,0 +1,26 @@
+//
+//  SplitViewContainer.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/8/23.
+//
+
+import SwiftUI
+
+struct SplitViewContainer: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+    var body: some View {
+        HStack(spacing: .zero) {
+            VideoContainer()
+            PracticeDetailContainer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .zIndex(viewStore.isFullScreenVideoVisible ? 0 : 1)
+    }
+}
+
+#Preview {
+    SplitViewContainer()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/SplitViewContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/SplitViewContainer.swift
@@ -53,4 +53,5 @@ struct SplitViewContainer: View {
                 summary: PracticeSummaryModel()
             ),
             mediaManager: MediaManager()))
+        .background(Color.HPGray.systemWhite)
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/SplitViewContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/SplitViewContainer.swift
@@ -6,10 +6,19 @@
 //
 
 import SwiftUI
+#if PREVIEW
+import SwiftData
+#endif
 
 struct SplitViewContainer: View {
     @Environment(PracticeViewStore.self)
     var viewStore
+    
+#if PREVIEW
+    // MARK: - MockData
+    @Query(sort: \PracticeModel.creatAt)
+    var practices: [PracticeModel]
+#endif
     
     var body: some View {
         HStack(spacing: .zero) {
@@ -18,9 +27,30 @@ struct SplitViewContainer: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .zIndex(viewStore.isFullScreenVideoVisible ? 0 : 1)
+        .onAppear {
+            // MARK: - Add MockData
+#if PREVIEW
+            if let sample = practices.first {
+                viewStore.practice = sample
+            }
+#endif
+        }
     }
 }
 
 #Preview {
-    SplitViewContainer()
+    let modelContainer = SwiftDataMockManager.previewContainer
+    
+    return SplitViewContainer()
+        .modelContainer(modelContainer)
+        .environment(PracticeViewStore(
+            practice: PracticeModel(
+                practiceName: "",
+                index: 0,
+                isVisited: false,
+                creatAt: "",
+                utterances: [],
+                summary: PracticeSummaryModel()
+            ),
+            mediaManager: MediaManager()))
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
@@ -12,50 +12,106 @@ struct VideoContainer: View {
     @Environment(PracticeViewStore.self)
     var viewStore
     
-    #if PREVIEW
+    // MARK: - 시간 초과한 프로젝트인 경우 체크 -> viewStore.practice.summary로 이동해야함.
+    @State
+    private var isTimeOverPractice = true
+    @State
+    private var planedTime = "7분 30초"
+    @State
+    private var overedTime = "3분 15초"
+    
+#if PREVIEW
     // MARK: - MockData
     @Query(sort: \PracticeModel.creatAt)
     var practices: [PracticeModel]
-    #endif
+#endif
     
     var body: some View {
-        VStack {
-            VStack {
-                header
-            }
-            VStack {
-                Text("Video Active")
-                    .onTapGesture {
-                        withAnimation {
-                            //                            viewStore.isFullScreenVideoVisible = true
-                        }
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: 200)
-                    .background(Color.gray)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        VStack(alignment: .leading, spacing: .zero) {
+            header
+            videoView
         }
+        .padding(.bottom, calcAudioIndicatorSize())
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.orange)
         .onAppear {
             // MARK: - Add MockData
-            #if PREVIEW
+#if PREVIEW
             if let sample = practices.first {
                 viewStore.practice = sample
             }
-            #endif
+#endif
         }
+    }
+}
+
+extension VideoContainer {
+    private func parseDateStyle(input: String) -> String {
+        Date.createAtToYearMonthDayWithTime(input: input)
+    }
+    
+    private func calcAudioIndicatorSize() -> CGFloat {
+        viewStore.currentFeedbackViewType != .every ? viewStore.AUDIO_INDICATOR_HEIGHT : .zero
     }
 }
 
 extension VideoContainer {
     @ViewBuilder
     private var header: some View {
-        VStack(spacing: 0) {
-            Text("NAME \(viewStore.practice.practiceName)")
-            Text("\(viewStore.practice.creatAt)")
-                .systemFont(.body)
-            Text("\(viewStore.practice.practiceName) 번째 연습")
+        VStack(alignment: .leading, spacing: .zero) {
+            Text("\(parseDateStyle(input: viewStore.practice.creatAt))")
+                .systemFont(.caption)
+                .foregroundStyle(Color.HPTextStyle.light)
+            Text("\(viewStore.practice.practiceName)")
+                .systemFont(.largeTitle)
+            HStack {
+                HPLabel(
+                    content: ("목표시간 \(planedTime)", "clock"),
+                    type: .blockFill(4),
+                    color: .HPGray.system200,
+                    alignStyle: .iconWithText,
+                    contentColor: .HPTextStyle.dark,
+                    fontStyle: .styled(.detailTimeFeedback),
+                    padding: (.HPSpacing.xxxxsmall, .HPSpacing.xxxsmall)
+                )
+                .fixedSize()
+                if isTimeOverPractice {
+                    HPLabel(
+                        content: ("+ \(overedTime) 초과", nil),
+                        type: .blockFill(4),
+                        color: .HPComponent.TimeFeedback.background,
+                        alignStyle: .iconWithText,
+                        contentColor: .HPComponent.TimeFeedback.text,
+                        fontStyle: .styled(.detailTimeFeedback),
+                        padding: (.HPSpacing.xxxxsmall, .HPSpacing.xxxsmall)
+                        
+                    )
+                    .fixedSize()
+                }
+            }
+        }
+        .padding(.top, .HPSpacing.small + .HPSpacing.xxxxsmall)
+        .padding(.leading, .HPSpacing.small)
+    }
+    
+    @ViewBuilder
+    private var videoView: some View {
+        GeometryReader { geometry in
+            VStack {
+                // MARK: - 영상으로 대체
+                Text("Video Active")
+                    .onTapGesture {
+                        withAnimation {
+                            viewStore.isFullScreenVideoVisible = true
+                        }
+                    }
+                    .frame(
+                        maxWidth: geometry.size.width,
+                        minHeight: geometry.size.width / 16 * 10
+                    )
+                    .background(Color.gray)
+            }
+            .padding(.vertical, .HPSpacing.xlarge)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
@@ -77,5 +133,6 @@ extension VideoContainer {
                 ),
                 mediaManager: MediaManager()))
     }
+    .frame(minHeight: 600)
     .padding(24)
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
@@ -8,31 +8,26 @@
 import SwiftUI
 import SwiftData
 
-import NaturalLanguage
-
 struct VideoContainer: View {
     @Environment(PracticeViewStore.self)
     var viewStore
     
-//    @Query(sort: \PracticeModel.creatAt)
-//    var practices: [PracticeModel]
+    #if PREVIEW
+    // MARK: - MockData
+    @Query(sort: \PracticeModel.creatAt)
+    var practices: [PracticeModel]
+    #endif
     
     var body: some View {
         VStack {
             VStack {
                 header
-//                Text("연습날짜")
-//                Text("연습 타이틀")
-//                HStack {
-//                    Text("목표시간")
-//                    Text("초과시간")
-//                }
             }
             VStack {
                 Text("Video Active")
                     .onTapGesture {
                         withAnimation {
-//                            viewStore.isFullScreenVideoVisible = true
+                            //                            viewStore.isFullScreenVideoVisible = true
                         }
                     }
                     .frame(maxWidth: .infinity, maxHeight: 200)
@@ -42,6 +37,14 @@ struct VideoContainer: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.orange)
+        .onAppear {
+            // MARK: - Add MockData
+            #if PREVIEW
+            if let sample = practices.first {
+                viewStore.practice = sample
+            }
+            #endif
+        }
     }
 }
 
@@ -49,10 +52,10 @@ extension VideoContainer {
     @ViewBuilder
     private var header: some View {
         VStack(spacing: 0) {
-            Text("NAME")
-//            Text("\(viewStore.practice.creatAt)")
-//                .systemFont(.body)
-//            Text("\(viewStore.practice.practiceName) 번째 연습")
+            Text("NAME \(viewStore.practice.practiceName)")
+            Text("\(viewStore.practice.creatAt)")
+                .systemFont(.body)
+            Text("\(viewStore.practice.practiceName) 번째 연습")
         }
     }
 }
@@ -60,15 +63,19 @@ extension VideoContainer {
 #Preview {
     let modelContainer = SwiftDataMockManager.previewContainer
     
-    return VideoContainer()
-//        .modelContainer(modelContainer)
-//        .environment(
-//            PracticeViewStore(practice: practices[0], mediaManager: MediaManager())
-//        )
-//        .environment(
-//            PracticeViewStore(
-//                practice: practice,
-//                mediaManager: MediaManager()
-//            )
-//        )
+    return VStack {
+        VideoContainer()
+            .modelContainer(modelContainer)
+            .environment(PracticeViewStore(
+                practice: PracticeModel(
+                    practiceName: "",
+                    index: 0,
+                    isVisited: false,
+                    creatAt: "",
+                    utterances: [],
+                    summary: PracticeSummaryModel()
+                ),
+                mediaManager: MediaManager()))
+    }
+    .padding(24)
 }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
@@ -50,7 +50,8 @@ extension VideoContainer {
     }
     
     private func calcAudioIndicatorSize() -> CGFloat {
-        viewStore.currentFeedbackViewType != .every ? viewStore.AUDIO_INDICATOR_HEIGHT : .zero
+//        viewStore.currentFeedbackViewType != .every ? viewStore.AUDIO_INDICATOR_HEIGHT : .zero
+        .zero
     }
 }
 

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/SplitViewContainer/VideoContainer/VideoContainer.swift
@@ -1,0 +1,74 @@
+//
+//  VideoContainer.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/8/23.
+//
+
+import SwiftUI
+import SwiftData
+
+import NaturalLanguage
+
+struct VideoContainer: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+//    @Query(sort: \PracticeModel.creatAt)
+//    var practices: [PracticeModel]
+    
+    var body: some View {
+        VStack {
+            VStack {
+                header
+//                Text("연습날짜")
+//                Text("연습 타이틀")
+//                HStack {
+//                    Text("목표시간")
+//                    Text("초과시간")
+//                }
+            }
+            VStack {
+                Text("Video Active")
+                    .onTapGesture {
+                        withAnimation {
+//                            viewStore.isFullScreenVideoVisible = true
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: 200)
+                    .background(Color.gray)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.orange)
+    }
+}
+
+extension VideoContainer {
+    @ViewBuilder
+    private var header: some View {
+        VStack(spacing: 0) {
+            Text("NAME")
+//            Text("\(viewStore.practice.creatAt)")
+//                .systemFont(.body)
+//            Text("\(viewStore.practice.practiceName) 번째 연습")
+        }
+    }
+}
+
+#Preview {
+    let modelContainer = SwiftDataMockManager.previewContainer
+    
+    return VideoContainer()
+//        .modelContainer(modelContainer)
+//        .environment(
+//            PracticeViewStore(practice: practices[0], mediaManager: MediaManager())
+//        )
+//        .environment(
+//            PracticeViewStore(
+//                practice: practice,
+//                mediaManager: MediaManager()
+//            )
+//        )
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/VideoControllerContainer/AudioIndicator/FillerWordAudioIndicator.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/VideoControllerContainer/AudioIndicator/FillerWordAudioIndicator.swift
@@ -1,0 +1,18 @@
+//
+//  FillerWordAudioIndicator.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/9/23.
+//
+
+import SwiftUI
+
+struct FillerWordAudioIndicator: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    FillerWordAudioIndicator()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/VideoControllerContainer/AudioIndicator/SpeedAudioIndicator.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/VideoControllerContainer/AudioIndicator/SpeedAudioIndicator.swift
@@ -1,0 +1,18 @@
+//
+//  SpeedAudioIndicator.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/9/23.
+//
+
+import SwiftUI
+
+struct SpeedAudioIndicator: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    SpeedAudioIndicator()
+}

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/VideoControllerContainer/VideoControllerContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/VideoControllerContainer/VideoControllerContainer.swift
@@ -1,0 +1,32 @@
+//
+//  VideoControllerContainer.swift
+//  highpitch
+//
+//  Created by yuncoffee on 11/8/23.
+//
+
+import SwiftUI
+
+struct VideoControllerContainer: View {
+    @Environment(PracticeViewStore.self)
+    var viewStore
+    
+    private let INDICATOR_HEIGHT = 32.0
+    
+    var body: some View {
+        VStack(spacing: .zero) {
+            viewStore.currentFeedbackViewType.audioIndicator
+                .frame(maxWidth:.infinity, maxHeight: 32)
+                .background(Color.yellow)
+            HStack {
+                Text("AudioController")
+            }
+            .frame(maxWidth:.infinity, maxHeight: 64)
+            .background(Color.red)
+        }
+    }
+}
+
+#Preview {
+    VideoControllerContainer()
+}

--- a/highpitch/Presentation/MenubarExtra/MenubarExtraHeader/MenubarExtraHeader.swift
+++ b/highpitch/Presentation/MenubarExtra/MenubarExtraHeader/MenubarExtraHeader.swift
@@ -49,6 +49,7 @@ extension MenubarExtraHeader {
         HStack(spacing: .HPSpacing.xxsmall) {
             openMainWindowButton
             openSettingWindowButton
+            openOverlayWindow
         }
     }
     
@@ -74,6 +75,23 @@ extension MenubarExtraHeader {
     private var openSettingWindowButton: some View {
         HPButton(type: .text, size: .medium, color: .HPGray.system800) {
             try? openSettings()
+        } label: { type, size, color, expandable in
+            HPLabel(
+                content: (label: "Open Settings", icon: "gearshape.fill"),
+                type: type,
+                size: size,
+                color: color,
+                alignStyle: .iconOnly,
+                expandable: expandable
+            )
+        }
+        .frame(width: 24, height: 24)
+    }
+    
+    @ViewBuilder
+    private var openOverlayWindow: some View {
+        HPButton(type: .text, size: .medium, color: .HPGray.system800) {
+            openWindow(id: "overlay3")
         } label: { type, size, color, expandable in
             HPLabel(
                 content: (label: "Open Settings", icon: "gearshape.fill"),

--- a/highpitch/Presentation/Overlay/OverlayView.swift
+++ b/highpitch/Presentation/Overlay/OverlayView.swift
@@ -44,12 +44,13 @@ class OverlayStore {
     var window: NSWindow
     
     init(window: NSWindow) {
-        window.level = NSWindow.Level(rawValue: 1000)
+        window.level = NSWindow.Level(rawValue: 9999)
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
-        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        window.standardWindowButton(.closeButton)?.isHidden = true
-        window.standardWindowButton(.zoomButton)?.isHidden = true
+//        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+//        window.standardWindowButton(.closeButton)?.isHidden = true
+//        window.standardWindowButton(.zoomButton)?.isHidden = true
+        window.collectionBehavior = .canJoinAllSpaces
         self.window = window
         self.window.isOpaque = false
         self.window.backgroundColor = NSColor.clear

--- a/highpitch/Presentation/Overlay/OverlayView.swift
+++ b/highpitch/Presentation/Overlay/OverlayView.swift
@@ -10,27 +10,19 @@ import SwiftUI
 struct OverlayView: View {
     @State private var window: NSWindow?
     @Binding var isActive: Bool
+    @State private var panel: NSPanel = NSPanel()
     
     var body: some View {
-        VStack {
-//            Text("Loading...")
-            Button {
-                window?.close()
-            } label: {
-                Text("Hello")
-            }
+        VStack(spacing: 0) {
+            Text("HHHzz")
             if nil != window {
-                MainView(store: OverlayStore(window: window!))
+                MainView(store: OverlayStore(window: panel))
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.HPTeritiery.base)
         .background(WindowAccessor(window: $window))
-        .onChange(of: isActive) { _, newValue in
-            if newValue {
-                window?.close()
-            }
-        }
+        .onChange(of: window, { oldValue, newValue in
+            print("window:", window)
+        })
     }
 }
 
@@ -44,16 +36,22 @@ class OverlayStore {
     var window: NSWindow
     
     init(window: NSWindow) {
-        window.level = NSWindow.Level(rawValue: 9999)
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = true
-//        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-//        window.standardWindowButton(.closeButton)?.isHidden = true
-//        window.standardWindowButton(.zoomButton)?.isHidden = true
-        window.collectionBehavior = .canJoinAllSpaces
-        self.window = window
+        print("Init window:", window)
+        let panel = NSPanel(
+            contentRect: NSRect(x: 200, y: 200, width: 400, height: 400),
+            styleMask: [.titled, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.backgroundColor = NSColor(.clear)
+        panel.level = .mainMenu
+        // .canJoinAllSpaces를 통해서 모든 Space 및 전체화면 위에도 띄울 수 있게
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.orderFrontRegardless()
+        self.window = panel
         self.window.isOpaque = false
         self.window.backgroundColor = NSColor.clear
+        self.window.orderFrontRegardless()
     }
 }
 
@@ -61,14 +59,31 @@ struct MainView: View {
     let store: OverlayStore
     
     var body: some View {
-        VStack {
-            Text("MainView with Window: \(store.window)")
-                .font(.title)
-                .foregroundStyle(Color.HPGray.systemWhite)
+        VStack {}
+        .onAppear {
+            store.window.contentView = NSHostingView(
+                rootView: SampleView(store: store)
+            )
+            print(store.window)
         }
-        .frame(width: 400, height: 200)
-        .background(Color.HPTextStyle.base)
-//        .background(.thickMaterial)
+    }
+}
+
+struct SampleView: View {
+    let store: OverlayStore
+    
+    var body: some View {
+        VStack {
+            Button {
+//                store.window.backgroundColor = .clear
+                store.window.close()
+            } label: {
+                Text("Close")
+            }
+
+            Text("Hello")
+        }
+        .padding(16)
     }
 }
 
@@ -83,5 +98,7 @@ struct WindowAccessor: NSViewRepresentable {
         return view
     }
     
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        print("nsView:", nsView)
+    }
 }

--- a/highpitch/Utils/Extension/Date+Extension.swift
+++ b/highpitch/Utils/Extension/Date+Extension.swift
@@ -115,6 +115,22 @@ extension Date {
         
         return result
     }
+    
+    static func createAtToYearMonthDayWithTime(input: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss ZZZZ"
+        
+        if let date = inputFormatter.date(from: input) {
+            let outputFormatter = DateFormatter()
+            outputFormatter.dateFormat = "yyyy년 M월 d일 • HH:mm"
+            
+            let dateString = outputFormatter.string(from: date)
+            
+            return dateString
+        } else {
+            return "Invalid Date"
+        }
+    }
 }
 
 extension Date {


### PR DESCRIPTION
# PR 요약
상태별로 변경되는 디테일 페이지의 ScriptView 영역을 작성하였습니다.
추가적으로 빌드 없이 프리뷰 환경에서 뷰를 테스트해볼 수 있도록 목 데이터 및 스키마를 작성하였습니다.
현재는 PracticeModel 한개에 대한 샘플만 작업하였습니다.

# 작업한 내용
- 0.1.0 기반의 swiftdata 목 데이터 추가
- 프리뷰용 스키마 추가
- PracticeView 0.2.0 디자인 레이아웃 작성
- PracticeView 상태 별 enum case 작성
- PracticeView 상태별 ScriptView 작성
- 뷰를 그리기 위한 리소스 추가
- 뷰 작성을 위한 디자인 시스템 일부 수정

# 참고 사항
- 목데이터 및 프리뷰 관련해서 궁금하신 분들 댓글 및 연락 남겨주세요.
- 목 데이터 및 프리뷰 사용 방법.

1. Xcode 스키마를 highpitch_preview로 변경
<img width="1109" alt="Screenshot 2023-11-12 at 2 57 22 PM" src="https://github.com/team-windup/highpitch/assets/88574289/4cbf68ec-3098-4007-99f5-69f4397ce818">

2. 프리뷰용 코드 작성

``` 사용하려는 뷰
import SwiftUI

/// 전처리 구문으로 PREVIEW 추가 - 해당 구문은 highpitch 스키마로 빌드 시 사용되지 않습니다.
#if PREVIEW 
import SwiftData
#endif

struct SampleView: View {
/// preview에서 swiftdata 데이터 쿼리
#if PREVIEW 
    // MARK: - MockData
    @Query(sort: \PracticeModel.creatAt)
    var practices: [PracticeModel]
#endif
    var body: some View {
        /// 데이터 바인딩
        Text("\(practices[0].practiceName)")
    }
}

#Preview {
    /// 샘플 데이터가 포함 된 프리뷰용 컨테이너를 가져옵니다. 
    let modelContainer = SwiftDataMockManager.previewContainer
    return SampleView()
        .modelContainer(modelContainer) // 해당 뷰에 환경으로 주입해줍니다.
}


```

# 관련 이슈
- resolved : #8 
