### PR TITLE
[Fix] 오디오 중복 제거 및 스크린 없이 녹화 버튼 제거 #81

### DIFF
--- a/highpitch/Managers/SystemManagers/MediaManager.swift
+++ b/highpitch/Managers/SystemManagers/MediaManager.swift
@@ -152,6 +152,10 @@ extension MediaManager: Recordable {
 
 // MARK: - 음성메모 재생 관련 메서드
 extension MediaManager: AudioPlayable {
+    func reset(){
+       audioPlayer = nil
+       avPlayer = nil
+    }
     func update() {
         MediaManager.count += 1
         if MediaManager.count == 10 {

--- a/highpitch/Managers/SystemManagers/ScreenRecordManager/ScreenRecordManager.swift
+++ b/highpitch/Managers/SystemManagers/ScreenRecordManager/ScreenRecordManager.swift
@@ -308,7 +308,9 @@ class ScreenRecordManager: ObservableObject {
                                                                                         onScreenWindowsOnly: false)
             availableDisplays = availableContent.displays
             
-            let windows = filterWindows(availableContent.windows)
+            let windows = filterWindows(availableContent.windows.filter({ window in
+                window.frame.width != 1.0 && window.frame.height != 1.0
+            }))
             if windows != availableWindows {
                 availableWindows = windows
             }

--- a/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
+++ b/highpitch/Presentation/MainWindow/ProjectView/PracticeView/v0.2.0/PracticeContentContainer.swift
@@ -53,6 +53,9 @@ struct PracticeContentContainer: View {
             }
 #endif
         }
+        .onDisappear {
+            viewStore.mediaManager.reset()
+        }
     }
 }
 extension PracticeContentContainer {

--- a/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
+++ b/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
@@ -107,11 +107,11 @@ extension ScreenSelectionView {
     @ViewBuilder
     var bottomButtons: some View {
         HStack {
-            Toggle(isOn: $isChecked) {
-                Text("화면 녹화 없이 연습하기")
-                    .systemFont(.caption, weight: .semibold)
-                    .foregroundColor(.HPTextStyle.base)
-            }
+//            Toggle(isOn: $isChecked) {
+//                Text("화면 녹화 없이 연습하기")
+//                    .systemFont(.caption, weight: .semibold)
+//                    .foregroundColor(.HPTextStyle.base)
+//            }
             Spacer()
             HStack {
                 Button(action: {
@@ -174,15 +174,16 @@ extension ScreenSelectionView {
         projectManager.pausePractice(mediaManager: mediaManager)
     }
     func startCapture() {
-        fileName = Date().makeM4aFileName()
         Task {
             await screenRecorder.stopPreview()
             // audioRecorder.startRecording(filename: fileName)
             // MARK: - 연습 시작
             SystemManager.shared.startInstantFeedback()
             playPractice()
-            fileName = mediaManager.fileName
-            await screenRecorder.start(fileName: fileName)
+            if(!isChecked) {
+                fileName = mediaManager.fileName
+                await screenRecorder.start(fileName: fileName)
+            }
         }
     }
     func stopPreview() {


### PR DESCRIPTION
# PR 요약
 오디오 중복 제거 및 스크린 없이 녹화 버튼 제거했습니다.
# 작업한 내용

- 오디오 중복 제거 (오디오 초기화)
- 스크린 없이 녹화 버튼 제거

# 참고 사항

-

# 관련 이슈

- resolved : #81 
