### PR TITLE
[Fix] NSPanel 위치 저장 수정 및 연습 저장하지 않기 구현

### DIFF
--- a/highpitch/App/AppDelegate.swift
+++ b/highpitch/App/AppDelegate.swift
@@ -61,15 +61,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             originalPos: originalYpos
         )
         
-        instantFeedbackManager.movablePanelMoved[0] = (xpos == originalXpos) ? false : true
-        instantFeedbackManager.movablePanelMoved[1] = (ypos == originalYpos) ? false : true
-        #if DEBUG
-        print("init Timer xpos: ", xpos)
-        print("init Timer ypos: ", ypos)
-        #endif
+        instantFeedbackManager.userDefaultsPanelPosition[0] = UserDefaults.standard.integer(forKey: "TimerPanelX")
+        instantFeedbackManager.userDefaultsPanelPosition[1] = UserDefaults.standard.integer(forKey: "TimerPanelY")
+        
         let timerPanelController = PanelController(
-            xpos: xpos - 11,
-            ypos: ypos - 11,
+            xpos: xpos,
+            ypos: ypos,
             width:
                 instantFeedbackManager.getTotalFrameWidth(
                     width: TIMER_PANEL_INFO.size.width,
@@ -150,16 +147,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             key: "SpeedPanelY",
             originalPos: originalYpos
         )
-        #if DEBUG
-        print("init Speed xpos: ", xpos)
-        print("init Speed ypos: ", ypos)
-        #endif
-        instantFeedbackManager.movablePanelMoved[2] = (xpos == originalXpos) ? false : true
-        instantFeedbackManager.movablePanelMoved[3] = (ypos == originalYpos) ? false : true
+        
+        instantFeedbackManager.userDefaultsPanelPosition[2] = UserDefaults.standard.integer(forKey: "SpeedPanelX")
+        instantFeedbackManager.userDefaultsPanelPosition[3] = UserDefaults.standard.integer(forKey: "SpeedPanelY")
         
         let speedPanelController = PanelController(
-            xpos: xpos - 11,
-            ypos: ypos - 11,
+            xpos: xpos,
+            ypos: ypos,
             width:
                 instantFeedbackManager.getTotalFrameWidth(
                     width: SPEED_PANEL_INFO.size.width,
@@ -201,16 +195,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             key: "FillerWordPanelY",
             originalPos: originalYpos
         )
-        #if DEBUG
-        print("init FillerWord xpos: ", xpos)
-        print("init FillerWord ypos: ", ypos)
-        #endif
-        instantFeedbackManager.movablePanelMoved[4] = (xpos == originalXpos) ? false : true
-        instantFeedbackManager.movablePanelMoved[5] = (ypos == originalYpos) ? true : false
+        
+        instantFeedbackManager.userDefaultsPanelPosition[4] = UserDefaults.standard.integer(forKey: "FillerWordPanelX")
+        instantFeedbackManager.userDefaultsPanelPosition[5] = UserDefaults.standard.integer(forKey: "FillerWordPanelY")
         
         let fillerWordPanelController = PanelController(
-            xpos: xpos - 11,
-            ypos: ypos - 11,
+            xpos: xpos,
+            ypos: ypos,
             width:
                 instantFeedbackManager.getTotalFrameWidth(
                     width: FILLERWORD_PANEL_INFO.size.width,

--- a/highpitch/App/HighPitchApp.swift
+++ b/highpitch/App/HighPitchApp.swift
@@ -83,6 +83,7 @@ struct HighpitchApp: App {
         systemManager.playPractice = playPractice
         systemManager.pausePractice = pausePractice
         systemManager.stopPractice = stopPractice
+        systemManager.notSavePractice = notSavePractice
         #if DEBUG
         print("시작할때 Start 키콤보: ",systemManager.hotkeyStart.keyCombo)
         print("시작할때 Pause 키콤보: ",systemManager.hotkeyPause.keyCombo)
@@ -253,6 +254,17 @@ extension HighpitchApp {
         Task {
             await MainActor.run {
                 projectManager.stopPractice(
+                    mediaManager: mediaManager,
+                    modelContext: container.mainContext
+                )
+            }
+        }
+    }
+    
+    func notSavePractice() {
+        Task {
+            await MainActor.run {
+                projectManager.notSavePractice(
                     mediaManager: mediaManager,
                     modelContext: container.mainContext
                 )

--- a/highpitch/Managers/ProjectManagers/ProjectManager.swift
+++ b/highpitch/Managers/ProjectManagers/ProjectManager.swift
@@ -115,6 +115,21 @@ extension ProjectManager {
         }
     }
     
+    @MainActor
+    func notSavePractice(
+        mediaManager: MediaManager,
+        modelContext: ModelContext
+    ) {
+        if !mediaManager.isRecording {
+            return
+        }
+        #if DEBUG
+        print("녹음 종료")
+        #endif
+        mediaManager.stopRecording()
+//        SystemManager.shared.isAnalyzing = true
+    }
+    
     private func makeNewUtterances(mediaManager: MediaManager) async -> [UtteranceModel] {
         var result: [UtteranceModel] = []
         do {

--- a/highpitch/Managers/SystemManagers/InstantFeedbackManager.swift
+++ b/highpitch/Managers/SystemManagers/InstantFeedbackManager.swift
@@ -25,8 +25,28 @@ final class InstantFeedbackManager {
     var speechRecognizerManager: SpeechRecognizerManager?
     var feedbackPanelControllers: [InstantPanel:PanelController] = [:]
     
-    var movablePanelMoved: [Bool] = [false, false, false, false, false, false]
-    var resetButtonDisabled = true
+    var standardPanelPosition: [Int] = [0,0,0,0,0,0]
+    var userDefaultsPanelPosition: [Int] = [0, 0, 0, 0, 0, 0] {
+        didSet(newVal) {
+            if userDefaultsPanelPosition[0] != standardPanelPosition[0] {
+                resetButtonDisabled = false
+            } else if userDefaultsPanelPosition[1] != standardPanelPosition[1] {
+                resetButtonDisabled = false
+            } else if userDefaultsPanelPosition[2] != standardPanelPosition[2] {
+                resetButtonDisabled = false
+            } else if userDefaultsPanelPosition[3] != standardPanelPosition[3] {
+                resetButtonDisabled = false
+            } else if userDefaultsPanelPosition[4] != standardPanelPosition[4] {
+                resetButtonDisabled = false
+            } else if userDefaultsPanelPosition[5] != standardPanelPosition[5] {
+                resetButtonDisabled = false
+            } else {
+                resetButtonDisabled = true
+            }
+        }
+    }
+    
+    var resetButtonDisabled = false
     
     var isTimerRunning = -2
     

--- a/highpitch/Managers/SystemManagers/SystemManager.swift
+++ b/highpitch/Managers/SystemManagers/SystemManager.swift
@@ -71,4 +71,5 @@ final class SystemManager {
     var playPractice: () -> Void = {}
     var pausePractice: () -> Void = {}
     var stopPractice: () -> Void = {}
+    var notSavePractice: () -> Void = {}
 }

--- a/highpitch/Presentation/MainWindow/Common/Sheet/MainWindowPracticeSaveSheet.swift
+++ b/highpitch/Presentation/MainWindow/Common/Sheet/MainWindowPracticeSaveSheet.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MainWindowPracticeSaveSheet: View {
+    var instantFeedbackManager = SystemManager.shared.instantFeedbackManager
+    
     var body: some View {
         ZStack(alignment: .topTrailing) {
             Button {
@@ -34,6 +36,14 @@ struct MainWindowPracticeSaveSheet: View {
                 }
                 HStack {
                     HPButton(type: .blockFill(8), size: .large, color: .HPGray.system200) {
+                        // 연습 저장 X, 녹음 종료 및 생성된 비디오, 오디오 삭제
+                        SystemManager.shared.notSavePractice()
+                        // TimerPanel의 타이머 정지 및 초기화
+                        SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
+                        NotificationCenter.default.post(name: Notification.Name("cancelButtonClicked"), object: true)
+                        instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
+                        instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
+                        
                         SystemManager.shared.isMainWindowPracticeSaveSheetActive = false
                     } label: { type, size, color, expandable in
                         HPLabel(
@@ -47,7 +57,13 @@ struct MainWindowPracticeSaveSheet: View {
                     }
                     .frame(width: 144)
                     HPButton(type: .blockFill(8), size: .large, color: .HPPrimary.base) {
-                        print("연습 저장하기")
+                        // 연습 저장하는 로직
+                        SystemManager.shared.stopPractice()
+                        // TimerPanel의 타이머 정지 및 초기화
+                        SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
+                        NotificationCenter.default.post(name: Notification.Name("stopButtonClicked"), object: true)
+                        instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
+                        instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
                     } label: { type, size, color, expandable in
                         HPLabel(
                             content: (label: "연습 저장하기", icon: nil),

--- a/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
+++ b/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
@@ -218,7 +218,7 @@ extension ScreenSelectionView {
     // 연습 저장하지 않고 끝내기
     func cancelCapture() {
         Task {
-            // audioRecorder.stopRecording()
+            audioRecorder.stopRecording()
             await screenRecorder.stopPreview()
             await screenRecorder.stop()
             SystemManager.shared.stopInstantFeedback()

--- a/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
+++ b/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
@@ -158,6 +158,12 @@ extension ScreenSelectionView {
                                                object: nil, queue: nil) { value in
             stopCapture()
         }
+        
+        // 연습 저장하지 않고 끝내기
+        NotificationCenter.default.addObserver(forName: Notification.Name("cancelButtonClicked"),
+                                               object: nil, queue: nil) { value in
+            cancelCapture()
+        }
     }
     private func playPractice() {
         #if DEBUG
@@ -208,6 +214,24 @@ extension ScreenSelectionView {
             }
         }
     }
+    
+    // 연습 저장하지 않고 끝내기
+    func cancelCapture() {
+        Task {
+            // audioRecorder.stopRecording()
+            await screenRecorder.stopPreview()
+            await screenRecorder.stop()
+            SystemManager.shared.stopInstantFeedback()
+            
+            do {
+                try FileManager.default.removeItem(at: URL.getPath(fileName: fileName, type: .video))
+                try FileManager.default.removeItem(at: URL.getPath(fileName: fileName, type: .audio))
+            } catch {
+                print("파일 삭제 실패")
+            }
+        }
+    }
+    
     func startPreview() {
         Task {
             if await screenRecorder.canRecord {

--- a/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
+++ b/highpitch/Presentation/MainWindow/ScreenRecordView/ScreenSelectionView.swift
@@ -218,7 +218,7 @@ extension ScreenSelectionView {
     // 연습 저장하지 않고 끝내기
     func cancelCapture() {
         Task {
-            audioRecorder.stopRecording()
+            // audioRecorder.stopRecording()
             await screenRecorder.stopPreview()
             await screenRecorder.stop()
             SystemManager.shared.stopInstantFeedback()

--- a/highpitch/Presentation/Overlay/FillerWordPanelView.swift
+++ b/highpitch/Presentation/Overlay/FillerWordPanelView.swift
@@ -80,18 +80,18 @@ struct FillerWordPanelView: View {
             } else {
                 // Hover Out 되었을때, 해당 위치를 UserDefaults에 넣는다.
                 UserDefaults.standard.set(
-                    String(Int(panelController.getPanelPosition()!.x)),
+                    Int(panelController.panel?.frame.origin.x ?? 0),
                     forKey: "FillerWordPanelX"
                 )
                 UserDefaults.standard.set(
-                    String(Int(panelController.getPanelPosition()!.y)),
+                    Int(panelController.panel?.frame.origin.y ?? 0),
                     forKey: "FillerWordPanelY"
                 )
-                #if DEBUG
-                print("HoverOut FillerWord xpos: \(Int(panelController.getPanelPosition()!.x))")
-                print("HoverOut FillerWord ypos: \(Int(panelController.getPanelPosition()!.y))")
-                #endif
+                 
                 instantFeedbackManager.focusedPanel = nil
+                
+                instantFeedbackManager.userDefaultsPanelPosition[4] = Int(panelController.getPanelPosition()!.x)
+                instantFeedbackManager.userDefaultsPanelPosition[5] = Int(panelController.getPanelPosition()!.y)
             }
         }
         .frame(

--- a/highpitch/Presentation/Overlay/RecordPanelView.swift
+++ b/highpitch/Presentation/Overlay/RecordPanelView.swift
@@ -16,53 +16,49 @@ struct RecordPanelView: View {
     let RECORD_PANEL_INFO = SystemManager.shared.instantFeedbackManager.RECORD_PANEL_INFO
     
     var body: some View {
-        ZStack {
-            Rectangle()
-                .frame(width:20, height: 20)
-                .foregroundStyle(Color("75707A"))
-                .offset(x:178.5, y:-14.5)
-            Rectangle()
-                .frame(width:20, height: 20)
-                .foregroundStyle(Color("3A3241"))
-                .offset(x:-178.5, y:-14.5)
-            
-            HStack(spacing:0) {
-                HStack {
-                    Circle()
-                        .opacity(circleOpacity)
-                        .foregroundColor(Color.red)
-                        .animation(
-                            .easeInOut(duration: 1).repeatForever(),
-                            value: circleOpacity
-                        )
-                        .frame(width:8, height: 8)
-                        .onAppear {
-                            circleOpacity = 1
-                        }
-                    Text("연습을 기록중이에요")
-                        .systemFont(.caption, weight: .semibold)
-                        .foregroundStyle(Color.white)
-                }
-                .frame(width:215, height: 29)
-                .background(Color("3A3241"))
-                
-                HStack(spacing: 0) {
-                    Button("연습 끝내기") {
-                        instantFeedbackManager.feedbackPanelControllers[.save]?.showPanel(self)
+        HStack(spacing:0) {
+            HStack {
+                Circle()
+                    .opacity(circleOpacity)
+                    .foregroundColor(Color.red)
+                    .animation(
+                        .easeInOut(duration: 1).repeatForever(),
+                        value: circleOpacity
+                    )
+                    .frame(width:8, height: 8)
+                    .onAppear {
+                        circleOpacity = 1
                     }
+                Text("연습을 기록중이에요")
                     .systemFont(.caption, weight: .semibold)
                     .foregroundStyle(Color.white)
-                    .buttonStyle(.plain)
-                }
-                .frame(width:142, height: 29)
-                .background(Color("75707A"))
             }
-            .frame(
-                width: RECORD_PANEL_INFO.size.width,
-                height: RECORD_PANEL_INFO.size.height
-            )
-            .background(Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous)) // Add clipShape here
+            .frame(width:215, height: 29)
+            .background(Color("3A3241"))
+            
+            HStack(spacing: 0) {
+                Button("연습 끝내기") {
+                    instantFeedbackManager.feedbackPanelControllers[.save]?.showPanel(self)
+                }
+                .systemFont(.caption, weight: .semibold)
+                .foregroundStyle(Color.white)
+                .buttonStyle(.plain)
+            }
+            .frame(width:142, height: 29)
+            .background(Color("75707A"))
         }
+        .frame(
+            width: RECORD_PANEL_INFO.size.width,
+            height: RECORD_PANEL_INFO.size.height
+        )
+        .background(Color.clear)
+        .clipShape(
+            .rect(
+                topLeadingRadius: 0,
+                bottomLeadingRadius: 12,
+                bottomTrailingRadius: 12,
+                topTrailingRadius: 0
+            )
+        )
     }
 }

--- a/highpitch/Presentation/Overlay/SavePanelView.swift
+++ b/highpitch/Presentation/Overlay/SavePanelView.swift
@@ -52,6 +52,10 @@ struct SavePanelView: View {
             
             HStack(alignment: .center) {
                 HPButton(color: .HPGray.system200) {
+                    // 연습 데이터 삭제
+                    NotificationCenter.default.post(name: Notification.Name("cancelButtonClicked"), object: true)
+                    
+                    SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
                     instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
                     instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
                 } label: { type, _, color, expandable in

--- a/highpitch/Presentation/Overlay/SavePanelView.swift
+++ b/highpitch/Presentation/Overlay/SavePanelView.swift
@@ -52,18 +52,13 @@ struct SavePanelView: View {
             
             HStack(alignment: .center, spacing: 12) {
                 HPButton(color: .HPGray.system200) {
-//                    // 연습 저장 X, 녹음 종료 및 생성된 비디오, 오디오 삭제
+                    // 연습 저장 X, 녹음 종료 및 생성된 비디오, 오디오 삭제
                     SystemManager.shared.notSavePractice()
                     // TimerPanel의 타이머 정지 및 초기화
                     SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
                     NotificationCenter.default.post(name: Notification.Name("cancelButtonClicked"), object: true)
                     instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
                     instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
-//                    SystemManager.shared.stopPractice()
-//                    SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
-//                    NotificationCenter.default.post(name: Notification.Name("stopButtonClicked"), object: true)
-//                    instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
-//                    instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
                 } label: { type, _, color, expandable in
                     HPLabel(
                         content: (label: "저장하지 않기", icon: nil),

--- a/highpitch/Presentation/Overlay/SavePanelView.swift
+++ b/highpitch/Presentation/Overlay/SavePanelView.swift
@@ -52,13 +52,18 @@ struct SavePanelView: View {
             
             HStack(alignment: .center, spacing: 12) {
                 HPButton(color: .HPGray.system200) {
-                    // 연습 저장 X, 녹음 종료 및 생성된 비디오, 오디오 삭제
+//                    // 연습 저장 X, 녹음 종료 및 생성된 비디오, 오디오 삭제
                     SystemManager.shared.notSavePractice()
                     // TimerPanel의 타이머 정지 및 초기화
                     SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
                     NotificationCenter.default.post(name: Notification.Name("cancelButtonClicked"), object: true)
                     instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
                     instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
+//                    SystemManager.shared.stopPractice()
+//                    SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
+//                    NotificationCenter.default.post(name: Notification.Name("stopButtonClicked"), object: true)
+//                    instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
+//                    instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
                 } label: { type, _, color, expandable in
                     HPLabel(
                         content: (label: "저장하지 않기", icon: nil),

--- a/highpitch/Presentation/Overlay/SavePanelView.swift
+++ b/highpitch/Presentation/Overlay/SavePanelView.swift
@@ -50,12 +50,13 @@ struct SavePanelView: View {
             
             Spacer()
             
-            HStack(alignment: .center) {
+            HStack(alignment: .center, spacing: 12) {
                 HPButton(color: .HPGray.system200) {
-                    // 연습 데이터 삭제
-                    NotificationCenter.default.post(name: Notification.Name("cancelButtonClicked"), object: true)
-                    
+                    // 연습 저장 X, 녹음 종료 및 생성된 비디오, 오디오 삭제
+                    SystemManager.shared.notSavePractice()
+                    // TimerPanel의 타이머 정지 및 초기화
                     SystemManager.shared.instantFeedbackManager.isTimerRunning = -1
+                    NotificationCenter.default.post(name: Notification.Name("cancelButtonClicked"), object: true)
                     instantFeedbackManager.feedbackPanelControllers[.save]?.hidePanel(self)
                     instantFeedbackManager.feedbackPanelControllers[.detailSetting]?.hidePanel(self)
                 } label: { type, _, color, expandable in

--- a/highpitch/Presentation/Overlay/SpeedPanelView.swift
+++ b/highpitch/Presentation/Overlay/SpeedPanelView.swift
@@ -91,19 +91,18 @@ struct SpeedPanelView: View {
             } else {
                 // Hover Out 되었을때, 해당 위치를 UserDefaults에 넣는다.
                 UserDefaults.standard.set(
-                    String(Int(panelController.getPanelPosition()!.x)),
+                    Int(panelController.panel?.frame.origin.x ?? 0),
                     forKey: "SpeedPanelX"
                 )
                 UserDefaults.standard.set(
-                    String(Int(panelController.getPanelPosition()!.y)),
+                    Int(panelController.panel?.frame.origin.y ?? 0),
                     forKey: "SpeedPanelY"
                 )
-                #if DEBUG
-                print("UserDefaults에 넣는다")
-                print("Hover아웃시 SpeedPanelController.getPanelPosition.x: \(Int(panelController.getPanelPosition()!.x))")
-                print("Hover아웃시 SpeedPanelController.getPanelPosition.y: \(Int(panelController.getPanelPosition()!.y))")
-                #endif
+                
                 instantFeedbackManager.focusedPanel = nil
+                
+                instantFeedbackManager.userDefaultsPanelPosition[2] = Int(panelController.getPanelPosition()!.x)
+                instantFeedbackManager.userDefaultsPanelPosition[3] = Int(panelController.getPanelPosition()!.y)
             }
         }
         .frame(

--- a/highpitch/Presentation/Overlay/TimerPanelView.swift
+++ b/highpitch/Presentation/Overlay/TimerPanelView.swift
@@ -101,40 +101,18 @@ struct TimerPanelView: View {
             } else {
                 // Hover Out 되었을때, 해당 위치를 UserDefaults에 넣는다.
                 UserDefaults.standard.set(
-                    String(Int(panelController.getPanelPosition()!.x)),
+                    Int(panelController.panel?.frame.origin.x ?? 0),
                     forKey: "TimerPanelX"
                 )
                 UserDefaults.standard.set(
-                    String(Int(panelController.getPanelPosition()!.y)),
+                    Int(panelController.panel?.frame.origin.y ?? 0),
                     forKey: "TimerPanelY"
                 )
-                #if DEBUG
-                print("UserDefaults에 넣겠습니다.")
-                print("xpos: \(panelController.getPanelPosition()!.x)")
-                print("ypos: \(panelController.getPanelPosition()!.y)")
-                #endif
+                
                 instantFeedbackManager.focusedPanel = nil
                 
-                let originalXpos = instantFeedbackManager.getPanelPositionX(
-                    left: TIMER_PANEL_INFO.topLeftPoint!.x,
-                    padding: XMARK_RADIUS
-                )
-                let originalYpos = instantFeedbackManager.getPanelPositionY(
-                    top: TIMER_PANEL_INFO.topLeftPoint!.y,
-                    height: TIMER_PANEL_INFO.size.height,
-                    padding: XMARK_RADIUS
-                )
-                
-                instantFeedbackManager.movablePanelMoved[0] = (Int(panelController.getPanelPosition()!.x) == originalXpos + 11) ? false : true
-                instantFeedbackManager.movablePanelMoved[1] = (Int(panelController.getPanelPosition()!.y) == originalYpos + 11) ? false : true
-                instantFeedbackManager.resetButtonDisabled = instantFeedbackManager.movablePanelMoved[0] ? false : true
-            }
-        }
-        .onChange(of: instantFeedbackManager.movablePanelMoved[0]) {
-            if instantFeedbackManager.movablePanelMoved[0] {
-                instantFeedbackManager.resetButtonDisabled = false
-            } else {
-                instantFeedbackManager.movablePanelMoved[0] = true
+                instantFeedbackManager.userDefaultsPanelPosition[0] = Int(panelController.getPanelPosition()!.x)
+                instantFeedbackManager.userDefaultsPanelPosition[1] = Int(panelController.getPanelPosition()!.y)
             }
         }
         .frame(


### PR DESCRIPTION
# PR 요약

# 작업한 내용

- NSPanel 위치 저장 string값에서 integer로 저장.
- NSPanel 중 timer, speed, fillerword에서 위치 변경 있으면 위치 되돌리기 버튼 활성화
- 연습 저장하지 않고 종료하기 기능 추가
- MainWindow에서도 연습 저장하기 및 종료하기 기능 추가

# 참고 사항

-

# 관련 이슈

- resolved : #이슈번호
